### PR TITLE
add postgresql vm test that runs in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
         name: selfhostblocks
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix flake check
-    - run: nix build .#checks.x86_64-linux.vms.postgresql
+    - run: nix build .#checks.x86_64-linux.vm_postgresql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,4 +10,10 @@ jobs:
     - uses: cachix/install-nix-action@v22
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
+    - uses: cachix/cachix-action@v12
+      with:
+        name: selfhostblocks
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix flake check
+    - run: nix build .#checks.x86_64-linux.vms.postgresql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
         name: selfhostblocks
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix flake check
-    # - run: nix build .#checks.x86_64-linux.vms.postgresql
+    - run: nix build .#checks.x86_64-linux.vms.postgresql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         name: selfhostblocks
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix flake check
+    - run: nix flake check -L

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,3 @@ jobs:
         name: selfhostblocks
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix flake check
-    - run: nix build .#checks.x86_64-linux.vm_postgresql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
         name: selfhostblocks
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix flake check
-    - run: nix build .#checks.x86_64-linux.vms.postgresql
+    # - run: nix build .#checks.x86_64-linux.vms.postgresql

--- a/README.md
+++ b/README.md
@@ -690,12 +690,15 @@ Run all tests:
 
 ```bash
 $ nix build .#checks.${system}.all
+# or
+$ nix flake check
 ```
 
 Run one group of tests:
 
 ```bash
-$ nix build .#checks.${system}.module
+$ nix build .#checks.${system}.modules
+$ nix build .#checks.${system}.vm_postgresql_peerAuth
 ```
 
 ### Deploy using colmena
@@ -795,6 +798,10 @@ $ nix run nixpkgs#openssl -- rand -hex 64
 - [ ] Fix tests on nix-darwin.
 
 ## Links that helped
+
+While creating NixOS tests:
+
+- https://www.haskellforall.com/2020/11/how-to-use-nixos-for-lightweight.html
 
 While creating an XML config generator for Radarr:
 

--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ $ nix run nixpkgs#openssl -- rand -hex 64
 While creating NixOS tests:
 
 - https://www.haskellforall.com/2020/11/how-to-use-nixos-for-lightweight.html
+- https://nixos.org/manual/nixos/stable/index.html#sec-nixos-tests
 
 While creating an XML config generator for Radarr:
 

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,10 @@
                   ./test/modules/postgresql.nix
                 ]);
             };
+
+            vms = {
+              postgresql = pkgs.callPackage ./test/vm/postgresql.nix {};
+            };
           };
       }
   );

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,11 @@
               }) files;
 
             mergeTests = pkgs.lib.lists.foldl pkgs.lib.trivial.mergeAttrs {};
-          in rec {
+
+            flattenAttrs = root: attrset: pkgs.lib.attrsets.foldlAttrs (acc: name: value: acc // {
+              "${root}_${name}" = value;
+            }) {} attrset;
+          in (rec {
             all = mergeTests [
               modules
             ];
@@ -59,9 +63,9 @@
                   ./test/modules/postgresql.nix
                 ]);
             };
-
-            vm_postgresql = pkgs.callPackage ./test/vm/postgresql.nix {};
-          };
+          }
+          // (flattenAttrs "vm_postgresql" (import ./test/vm/postgresql.nix {inherit pkgs; inherit (pkgs) lib;}))
+          );
       }
   );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = inputs@{ self, nixpkgs, sops-nix, nix-flake-tests, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
+  outputs = { nixpkgs, nix-flake-tests, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = nixpkgs.legacyPackages.${system};
     in

--- a/flake.nix
+++ b/flake.nix
@@ -60,9 +60,7 @@
                 ]);
             };
 
-            vms = {
-              postgresql = pkgs.callPackage ./test/vm/postgresql.nix {};
-            };
+            vm_postgresql = pkgs.callPackage ./test/vm/postgresql.nix {};
           };
       }
   );

--- a/modules/blocks/authelia.nix
+++ b/modules/blocks/authelia.nix
@@ -279,7 +279,7 @@ in
       user = autheliaCfg.user;
     };
 
-    shb.postgresql.passwords = [
+    shb.postgresql.ensures = [
       {
         username = autheliaCfg.user;
         database = autheliaCfg.user;

--- a/modules/blocks/monitoring.nix
+++ b/modules/blocks/monitoring.nix
@@ -36,7 +36,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    shb.postgresql.passwords = [
+    shb.postgresql.ensures = [
       {
         username = "grafana";
         database = "grafana";

--- a/modules/services/vaultwarden.nix
+++ b/modules/services/vaultwarden.nix
@@ -183,8 +183,8 @@ in
       }
     ];
 
-    shb.postgresql.tcpIPPort= 5432;
-    shb.postgresql.passwords = [
+    shb.postgresql.enableTCPIP = true;
+    shb.postgresql.ensures = [
       {
         username = "vaultwarden";
         database = "vaultwarden";

--- a/test/modules/postgresql.nix
+++ b/test/modules/postgresql.nix
@@ -68,7 +68,7 @@ in
       systemd.services.postgresql.postStart = "";
     };
     expr = testConfig {
-      shb.postgresql.passwords = [
+      shb.postgresql.ensures = [
         {
           username = "myuser";
           database = "mydatabase";
@@ -104,7 +104,7 @@ in
       '';
     };
     expr = testConfig {
-      shb.postgresql.passwords = [
+      shb.postgresql.ensures = [
         {
           username = "myuser";
           database = "mydatabase";
@@ -143,7 +143,7 @@ in
       systemd.services.postgresql.postStart = "";
     };
     expr = testConfig {
-      shb.postgresql.passwords = [
+      shb.postgresql.ensures = [
         {
           username = "user1";
           database = "db1";
@@ -196,7 +196,7 @@ in
       '';
     };
     expr = testConfig {
-      shb.postgresql.passwords = [
+      shb.postgresql.ensures = [
         {
           username = "user1";
           database = "db1";
@@ -249,7 +249,7 @@ in
       '';
     };
     expr = testConfig {
-      shb.postgresql.passwords = [
+      shb.postgresql.ensures = [
         {
           username = "user1";
           database = "db1";
@@ -271,20 +271,19 @@ in
         ensureDatabases = [];
         
         enableTCPIP = true;
-        port = 1234;
         authentication = ''
           #type database DBuser origin-address auth-method
           local all      all    peer
           # ipv4
-          host  all      all    127.0.0.1/32   trust
+          host  all      all    127.0.0.1/32   password
           # ipv6
-          host  all      all    ::1/128        trust
+          host  all      all    ::1/128        password
         '';
       };
       systemd.services.postgresql.postStart = "";
     };
     expr = testConfig {
-      shb.postgresql.tcpIPPort = 1234;
+      shb.postgresql.enableTCPIP = true;
     };
   };
 }

--- a/test/vm/postgresql.nix
+++ b/test/vm/postgresql.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, ... }:
 {
   peerWithoutUser = pkgs.nixosTest {
-    name = "postgresql";
+    name = "postgresql-peerWithoutUser";
 
     nodes.machine = { config, pkgs, ... }: {
       imports = [
@@ -35,7 +35,7 @@
   };
 
   peerAuth = pkgs.nixosTest {
-    name = "postgresql";
+    name = "postgresql-peerAuth";
 
     nodes.machine = { config, pkgs, ... }: {
       imports = [
@@ -82,7 +82,7 @@
   };
 
   tcpIPWithoutPasswordAuth = pkgs.nixosTest {
-    name = "postgresql";
+    name = "postgresql-tcpIpWithoutPasswordAuth";
 
     nodes.machine = { config, pkgs, ... }: {
       imports = [
@@ -117,7 +117,7 @@
   };
 
   tcpIPPasswordAuth = pkgs.nixosTest {
-    name = "postgresql";
+    name = "postgresql-tcpIPPasswordAuth";
 
     nodes.machine = { config, pkgs, ... }: {
       imports = [

--- a/test/vm/postgresql.nix
+++ b/test/vm/postgresql.nix
@@ -14,5 +14,6 @@ in pkgs.nixosTest {
 
   testScript = { nodes, ... }: ''
   start_all()
+  machine.wait_for_unit("postgresql.service")
   '';
 }

--- a/test/vm/postgresql.nix
+++ b/test/vm/postgresql.nix
@@ -1,19 +1,167 @@
 { pkgs, lib, ... }:
-let
+{
+  peerWithoutUser = pkgs.nixosTest {
+    name = "postgresql";
 
-in pkgs.nixosTest {
-  name = "postgresql";
+    nodes.machine = { config, pkgs, ... }: {
+      imports = [
+        ../../modules/blocks/postgresql.nix
+      ];
 
-  nodes.machine = { config, pkgs, ... }: {
-    imports = [
-      ../../modules/blocks/postgresql.nix
-    ];
+      shb.postgresql.ensures = [
+        {
+          username = "me";
+          database = "mine";
+        }
+      ];
+    };
 
-    services.postgresql.enable = true;
+    testScript = { nodes, ... }: ''
+    start_all()
+    machine.wait_for_unit("postgresql.service")
+
+    def peer_cmd(user, database):
+        return "sudo -u me psql -U {user} {db} --command \"\"".format(user=user, db=database)
+
+    with subtest("cannot login because of missing user"):
+        machine.fail(peer_cmd("me", "mine"), timeout=10)
+
+    with subtest("cannot login with unknown user"):
+        machine.fail(peer_cmd("notme", "mine"), timeout=10)
+
+    with subtest("cannot login to unknown database"):
+        machine.fail(peer_cmd("me", "notmine"), timeout=10)
+    '';
   };
 
-  testScript = { nodes, ... }: ''
-  start_all()
-  machine.wait_for_unit("postgresql.service")
-  '';
+  peerAuth = pkgs.nixosTest {
+    name = "postgresql";
+
+    nodes.machine = { config, pkgs, ... }: {
+      imports = [
+        ../../modules/blocks/postgresql.nix
+      ];
+
+      users.users.me = {
+        isSystemUser = true;
+        group = "me";
+        extraGroups = [ "sudoers" ];
+      };
+      users.groups.me = {};
+
+      shb.postgresql.ensures = [
+        {
+          username = "me";
+          database = "mine";
+        }
+      ];
+    };
+
+    testScript = { nodes, ... }: ''
+    start_all()
+    machine.wait_for_unit("postgresql.service")
+
+    def peer_cmd(user, database):
+        return "sudo -u me psql -U {user} {db} --command \"\"".format(user=user, db=database)
+
+    def tcpip_cmd(user, database, port):
+        return "psql -h 127.0.0.1 -p {port} -U {user} {db} --command \"\"".format(user=user, db=database, port=port)
+
+    with subtest("can login with provisioned user and database"):
+        machine.succeed(peer_cmd("me", "mine"), timeout=10)
+
+    with subtest("cannot login with unknown user"):
+        machine.fail(peer_cmd("notme", "mine"), timeout=10)
+
+    with subtest("cannot login to unknown database"):
+        machine.fail(peer_cmd("me", "notmine"), timeout=10)
+
+    with subtest("cannot login with tcpip"):
+        machine.fail(tcpip_cmd("me", "mine", "5432"), timeout=10)
+    '';
+  };
+
+  tcpIPWithoutPasswordAuth = pkgs.nixosTest {
+    name = "postgresql";
+
+    nodes.machine = { config, pkgs, ... }: {
+      imports = [
+        ../../modules/blocks/postgresql.nix
+      ];
+
+      shb.postgresql.enableTCPIP = true;
+      shb.postgresql.ensures = [
+        {
+          username = "me";
+          database = "mine";
+        }
+      ];
+    };
+
+    testScript = { nodes, ... }: ''
+    start_all()
+    machine.wait_for_unit("postgresql.service")
+
+    def peer_cmd(user, database):
+        return "sudo -u me psql -U {user} {db} --command \"\"".format(user=user, db=database)
+
+    def tcpip_cmd(user, database, port):
+        return "psql -h 127.0.0.1 -p {port} -U {user} {db} --command \"\"".format(user=user, db=database, port=port)
+
+    with subtest("cannot login without existing user"):
+        machine.fail(peer_cmd("me", "mine"), timeout=10)
+
+    with subtest("cannot login with user without password"):
+        machine.fail(tcpip_cmd("me", "mine", "5432"), timeout=10)
+    '';
+  };
+
+  tcpIPPasswordAuth = pkgs.nixosTest {
+    name = "postgresql";
+
+    nodes.machine = { config, pkgs, ... }: {
+      imports = [
+        ../../modules/blocks/postgresql.nix
+      ];
+
+      users.users.me = {
+        isSystemUser = true;
+        group = "me";
+        extraGroups = [ "sudoers" ];
+      };
+      users.groups.me = {};
+
+      system.activationScripts.secret = ''
+      echo secretpw > /run/dbsecret
+      '';
+      shb.postgresql.enableTCPIP = true;
+      shb.postgresql.ensures = [
+        {
+          username = "me";
+          database = "mine";
+          passwordFile = "/run/dbsecret";
+        }
+      ];
+    };
+
+    testScript = { nodes, ... }: ''
+    start_all()
+    machine.wait_for_unit("postgresql.service")
+
+    def peer_cmd(user, database):
+        return "sudo -u me psql -U {user} {db} --command \"\"".format(user=user, db=database)
+
+    def tcpip_cmd(user, database, port, password):
+        return "PGPASSWORD={password} psql -h 127.0.0.1 -p {port} -U {user} {db} --command \"\"".format(user=user, db=database, port=port, password=password)
+
+    with subtest("can peer login with provisioned user and database"):
+        machine.succeed(peer_cmd("me", "mine"), timeout=10)
+
+    with subtest("can tcpip login with provisioned user and database"):
+        machine.succeed(tcpip_cmd("me", "mine", "5432", "secretpw"), timeout=10)
+
+    with subtest("cannot tcpip login with wrong password"):
+        machine.fail(tcpip_cmd("me", "mine", "5432", "oops"), timeout=10)
+    '';
+  };
 }

--- a/test/vm/postgresql.nix
+++ b/test/vm/postgresql.nix
@@ -5,7 +5,11 @@ in pkgs.nixosTest {
   name = "postgresql";
 
   nodes.machine = { config, pkgs, ... }: {
-    
+    imports = [
+      ../../modules/blocks/postgresql.nix
+    ];
+
+    services.postgresql.enable = true;
   };
 
   testScript = { nodes, ... }: ''

--- a/test/vm/postgresql.nix
+++ b/test/vm/postgresql.nix
@@ -1,0 +1,14 @@
+{ pkgs, lib, ... }:
+let
+
+in pkgs.nixosTest {
+  name = "postgresql";
+
+  nodes.machine = { config, pkgs, ... }: {
+    
+  };
+
+  testScript = { nodes, ... }: ''
+  start_all()
+  '';
+}


### PR DESCRIPTION
Fixes #14 

The tests actually showed a flaw in the implementation, we needed "password" and not "trust" in the auth file.

Also, having the port defined at the same time as enabling listening for TCP/IP connection made no sense.