### PR TITLE
fix storage creation in homeassistant on first run

### DIFF
--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -174,10 +174,13 @@ in
           }
         }
         '';
-        file = "${config.services.home-assistant.configDir}/.storage/onboarding";
+        storage = "${config.services.home-assistant.configDir}/.storage";
+        file = "${storage}/onboarding";
       in
       ''
-      -f ${file} || cp ${onboarding} ${file}
+      if ! -f ${file}; then
+        mkdir -p ${storage} && cp ${onboarding} ${file}
+      fi
       '';
 
     sops.secrets."home-assistant" = {


### PR DESCRIPTION
This appeared in the demo. Of course, we should have a test for this.