### PR TITLE
Fixes #126 Authelia OIDC client fix

### DIFF
--- a/modules/services/jellyfin.nix
+++ b/modules/services/jellyfin.nix
@@ -383,7 +383,7 @@ in
         id = cfg.oidcClientID;
         description = "Jellyfin";
         secretFile = config.sops.secrets."authelia/jellyfin_sso_secret".path;
-        public = "false";
+        public = false;
         authorization_policy = "one_factor";
         redirect_uris = [ "https://${cfg.subdomain}.${cfg.domain}/sso/OID/r/${cfg.oidcProvider}" ];
       }

--- a/test/vm/authelia.nix
+++ b/test/vm/authelia.nix
@@ -51,7 +51,7 @@ in
             id = "myclient";
             description = "My Client";
             secretFile = pkgs.writeText "secret" "mysecuresecret";
-            public = "false";
+            public = false;
             authorization_policy = "one_factor";
             redirect_uris = [ "https://myclient.exapmle.com/redirect" ];
           }


### PR DESCRIPTION
Fixes #126 

* Make a single yaml file to configure Authelia clients instead of one for each client.
* Changed sed pattern / template function to allow multiple replacement
* Changed 'public' attribute of OIDC clients to be of type bool (was string)

Haven't yet tested this properly.