### PR TITLE
fix nextcloud openssl path

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -524,7 +524,6 @@ in
           "opcache.max_accelerated_files" = "10000";
           "opcache.memory_consumption" = "128";
           "opcache.revalidate_freq" = "1";
-          "openssl.cafile" = "/etc/ssl/certs/ca-certificates.cert";
           short_open_tag = "Off";
 
           output_buffering = "Off";


### PR DESCRIPTION
I don't remember why I hardcoded this, but the default works fine.