### PR TITLE
Revert to loki v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Upcoming
+
+# 0.1.0
+
+Creation of CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+- Revert Loki to major version 2 because upgrading to version 3 required manual intervention as Loki
+  refuses to start. So until this issue is tackled, reverting is the best immediate fix.
+  See https://github.com/NixOS/nixpkgs/commit/8f95320f39d7e4e4a29ee70b8718974295a619f4
+
 # 0.1.0
 
 Creation of CHANGELOG.md


### PR DESCRIPTION
This is needed because v3 requires manual intervention to upgrade otherwise Loki refuses to start. So until there's a fix, reverting is the easiest fix.