### PR TITLE
do not set serverAliases for dns

### DIFF
--- a/modules/blocks/ssl.nix
+++ b/modules/blocks/ssl.nix
@@ -441,7 +441,6 @@ in
               virtualHosts."${name}" = {
                 addSSL = true;
                 enableACME = true;
-                serverAliases = certCfg.extraDomains;
                 # locations."/" = {
                 #   root = "/var/www";
                 # };


### PR DESCRIPTION
Otherwise, those server aliases take precedence over actual virtual hosts that serve those subdomain.