### PR TITLE
Update SSO setup for Audiobookshelf

### DIFF
--- a/test/services/audiobookshelf.nix
+++ b/test/services/audiobookshelf.nix
@@ -69,13 +69,22 @@ let
 
   sso = { config, ... }: {
     shb.audiobookshelf = {
-      authEndpoint = "https://${config.shb.authelia.subdomain}.${config.shb.authelia.domain}";
-      ssoSecret.result = config.shb.hardcodedsecret.ssoSecret.result;
+      sso = {
+        enable = true;
+        endpoint = "https://${config.shb.authelia.subdomain}.${config.shb.authelia.domain}";
+        sharedSecret.result = config.shb.hardcodedsecret.audiobookshelfSSOPassword.result;
+        sharedSecretForAuthelia.result = config.shb.hardcodedsecret.audiobookshelfSSOPasswordAuthelia.result;
+      };
     };
 
-    shb.hardcodedsecret.ssoSecret = {
-      request = config.shb.audiobookshelf.ssoSecret.request;
-      settings.content = "ssoSecret";
+    shb.hardcodedsecret.audiobookshelfSSOPassword = {
+      request = config.shb.audiobookshelf.sso.sharedSecret.request;
+      settings.content = "ssoPassword";
+    };
+
+    shb.hardcodedsecret.audiobookshelfSSOPasswordAuthelia = {
+      request = config.shb.audiobookshelf.sso.sharedSecretForAuthelia.request;
+      settings.content = "ssoPassword";
     };
   };
 in


### PR DESCRIPTION
I noticed that the audiobookshelf SSO config was outdated, so I updated it according to the current Jellyfin config to make SSO work again.

The only notable exception is the `token_endpoint_auth_method` which needs to be `client_secret_basic` for Audiobookshelf

I've ran the VM test with , and tested that SSO is working on my server.