### PR TITLE
add back info into authelia id token

### DIFF
--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -101,6 +101,9 @@
   "blocks-authelia-options-shb.authelia.oidcClients._.authorization_policy": [
     "blocks-authelia.html#blocks-authelia-options-shb.authelia.oidcClients._.authorization_policy"
   ],
+  "blocks-authelia-options-shb.authelia.oidcClients._.claims_policy": [
+    "blocks-authelia.html#blocks-authelia-options-shb.authelia.oidcClients._.claims_policy"
+  ],
   "blocks-authelia-options-shb.authelia.oidcClients._.client_id": [
     "blocks-authelia.html#blocks-authelia-options-shb.authelia.oidcClients._.client_id"
   ],

--- a/modules/blocks/authelia.nix
+++ b/modules/blocks/authelia.nix
@@ -209,6 +209,17 @@ in
             example = [ "openid" "profile" "email" "groups" ];
             default = [];
           };
+
+          claims_policy = lib.mkOption {
+            type = lib.types.str;
+            description = ''
+              Claim policy.
+
+              Defaults to 'default' to provide a backwards compatible experience.
+              Read [this document](https://www.authelia.com/integration/openid-connect/openid-connect-1.0-claims/#restore-functionality-prior-to-claims-parameter) for more information.
+            '';
+            default = "default";
+          };
         };
       });
     };
@@ -367,24 +378,19 @@ in
             disable = "false";
           };
           ldap = {
-            implementation = "custom";
+            implementation = "lldap";
             address = "ldap://${cfg.ldapHostname}:${toString cfg.ldapPort}";
             timeout = "5s";
             start_tls = "false";
             base_dn = cfg.dcdomain;
-            additional_users_dn = "ou=people";
-            # Sign in with username or email.
-            users_filter = "(&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person))";
-            additional_groups_dn = "ou=groups";
-            groups_filter = "(member={dn})";
+            # TODO: use user with less privilege and with lldap_password_manager group to be able to change passwords.
             user = "uid=admin,ou=people,${cfg.dcdomain}";
-            attributes = {
-              username = "uid";
-              group_name = "cn";
-              mail = "mail";
-              display_name = "displayName";
-            };
           };
+        };
+        # This should go away at some point.
+        # https://www.authelia.com/integration/openid-connect/openid-connect-1.0-claims/#restore-functionality-prior-to-claims-parameter
+        identity_providers.oidc = {
+          claims_policies.default.id_token = [ "email" "preferred_username" "name" "groups" ];
         };
         totp = {
           disable = "false";


### PR DESCRIPTION
This was necessary because of a recent update to Authelia. I followed the steps outlined in https://www.authelia.com/integration/openid-connect/openid-connect-1.0-claims/#restore-functionality-prior-to-claims-parameter