### PR TITLE
nextcloud: fix permission on nextcloud server

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -952,7 +952,6 @@ in
       systemd.services.nextcloud-cron-previewgenerator = {
         environment.NEXTCLOUD_CONFIG_DIR = "${config.services.nextcloud.datadir}/config";
         serviceConfig.Type = "oneshot";
-        serviceConfig.User = "nextcloud";
         serviceConfig.ExecStart =
           let
             debug = if cfg.debug or cfg.apps.previewgenerator.debug then "-vvv" else "";


### PR DESCRIPTION
nextcloud-occ is a wrapper around systemd-run so we must be root to run it.