### PR TITLE
forgejo: clean backup dumps

### DIFF
--- a/modules/services/forgejo.nix
+++ b/modules/services/forgejo.nix
@@ -408,6 +408,7 @@ in
         type = "tar.gz";
         interval = "hourly";
       };
+      systemd.services.forgejo-dump.preStart = "rm -f ${config.services.forgejo.dump.backupDir}/*.tar.gz";
     })
 
     # For Forgejo setup: https://github.com/lldap/lldap/blob/main/example_configs/gitea.md

--- a/modules/services/forgejo/docs/default.md
+++ b/modules/services/forgejo/docs/default.md
@@ -165,6 +165,10 @@ twice with a future secrets SHB block.
 
 ### Backup {#services-forgejo-usage-backup}
 
+Every hour, Forgejo takes a backup using the [built-in `dump` command](https://forgejo.org/docs/latest/admin/command-line/#dump).
+This backup is ephemeral and should be moved in a permanent location.
+This can be accomplished using the following config.
+
 Backing up Forgejo using the [Restic block](blocks-restic.html) is done like so:
 
 ```nix


### PR DESCRIPTION
This assumes the dumps are moved elsewhere. Closes #519.