### PR TITLE
Improve CI behavior

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
         if: always()
         with:
           name: ${{ matrix.check }}
-          path: ${{ env.resultPath }}/**/*
+          path: ${{ env.resultPath }}/trace/*
           overwrite: true
 
   results:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -123,7 +123,7 @@ jobs:
           nix build --print-build-logs --show-trace --keep-outputs --keep-failed .#checks.x86_64-linux.${{ matrix.check }}
       - name: Upload Build Result
         uses: actions/upload-artifact@v4
-        if: always()
+        if: startsWith(matrix.check, 'vm_')
         with:
           name: ${{ matrix.check }}
           path: ${{ env.resultPath }}/trace/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ "build-matrix" ]
     strategy:
+      fail-fast: false
       matrix:
         check: ${{ fromJson(needs.build-matrix.outputs.check) }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,6 +128,7 @@ jobs:
           name: ${{ matrix.check }}
           path: ${{ env.resultPath }}/trace/*
           overwrite: true
+          if-no-files-found: ignore
 
   results:
     name: Final Results


### PR DESCRIPTION
- Let all tests finish even if one fails. This helps see if other tests fail and also not waste time since successful tests will be cached.
- Reduce kept artifacts to only traces.