### PR TITLE
usage.md - sops: fix import

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,11 @@ Host Blocks:
 
 If you use `sops-nix` for secrets, SHB provides an additional module, not
 imported in the `default` module. It can be added by importing
-`inputs.selfhostblocks.sops`.
+
+```
+inputs.sops-nix.nixosModules.default
+inputs.selfhostblocks.nixosModules.sops
+```
 
 ### SHB Lib {#usage-flake-lib}
 
@@ -529,7 +533,10 @@ One way to setup secrets management using `sops-nix`:
 5. Use `sops-nix` module in nix:
    ```bash
    imports = [
-       selfhostblocks.inputs.sops-nix.nixosModules.default
+       
+    inputs.sops-nix.nixosModules.default
+    inputs.selfhostblocks.nixosModules.sops
+
    ];
    ```
 6. Set default sops file:


### PR DESCRIPTION
In the sops section of the usage page in the docs, it's imported incorrectly, as in the modules it tells you to import aren't actually the ones you need to import, I replaced that with the correct ones here