### PR TITLE
#583 Immich: add authelia bypass for mobile app

### DIFF
--- a/modules/services/immich.nix
+++ b/modules/services/immich.nix
@@ -546,6 +546,14 @@ in
         autheliaRules = lib.mkIf (cfg.sso.enable) [
           {
             domain = fqdn;
+            policy = "bypass";
+            resources = [
+              "^/api.*"
+              "^/.well-known/immich"
+            ];
+          }
+          {
+            domain = fqdn;
             policy = cfg.sso.authorization_policy;
             subject = [
               "group:immich_user"


### PR DESCRIPTION
Adds bypasses for /api and /.well-known/immich so that the mobile app authentication works.