### PR TITLE
Immich: Added options to make LAN access possible

### DIFF
--- a/modules/services/immich.nix
+++ b/modules/services/immich.nix
@@ -144,6 +144,15 @@ in
       default = 2283;
     };
 
+    host = mkOption {
+      description = ''
+        Host address Immich will listen on.
+        Set this to 0.0.0.0 for LAN access
+      '';
+      type = str;
+      default = "127.0.0.1";
+    };
+
     ssl = mkOption {
       description = "Path to SSL files";
       type = nullOr contracts.ssl.certs;
@@ -325,6 +334,15 @@ in
             default = true;
           };
 
+          extraRedirectUris = mkOption {
+            description = "Extra redirect URIs for Authelia. Can be used when using local IP connection on home network.";
+            type = listOf str;
+            default = [ ];
+            example = [
+              "http://192.168.0.5:2284/auth/login"
+            ];
+          };
+
           sharedSecret = mkOption {
             description = "OIDC shared secret for Immich.";
             type = submodule {
@@ -466,7 +484,7 @@ in
     # Configure Immich service
     services.immich = {
       enable = true;
-      host = "127.0.0.1";
+      host = cfg.host;
       port = cfg.port;
       mediaLocation = cfg.mediaLocation;
 
@@ -628,7 +646,9 @@ in
           "${protocol}://${fqdn}/auth/login"
           "${protocol}://${fqdn}/user-settings"
           "app.immich:///oauth-callback"
-        ];
+          "http://192.168.0.102:2284/auth/login"
+        ]
+        ++ cfg.sso.extraRedirectUris;
         inherit scopes;
       }
     ];


### PR DESCRIPTION
The immich app has a feature to switch to another URL when on a specific wifi network (e.g. home network). This change adds an option for listen address so that the server can listen on LAN traffic. For this to work with authelia, we need to add the appropriate redirect URL as well.

This is very handy for those of us who are using a proxy which blocks large file uploads -- large files will then get synced automatically when connecting to the home network.