### PR TITLE
docs: distinguish description for contract databasebackup from backup's

### DIFF
--- a/modules/contracts/backup.nix
+++ b/modules/contracts/backup.nix
@@ -158,7 +158,7 @@ in
       description = ''
         Result part of the backup contract.
 
-        Options set by the provider module that indicates the name of the backup and restor scripts.
+        Options set by the provider module that indicates the name of the backup and restore scripts.
       '';
       default = {
         inherit restoreScript backupService;

--- a/modules/contracts/databasebackup.nix
+++ b/modules/contracts/databasebackup.nix
@@ -24,7 +24,7 @@ in
     }:
     mkOption {
       description = ''
-        Request part of the backup contract.
+        Request part of the database backup contract.
 
         Options set by the requester module
         enforcing how to backup files.
@@ -122,9 +122,9 @@ in
     }:
     mkOption {
       description = ''
-        Result part of the backup contract.
+        Result part of the database backup contract.
 
-        Options set by the provider module that indicates the name of the backup and restor scripts.
+        Options set by the provider module that indicates the name of the backup and restore scripts.
       '';
       default = {
         inherit restoreScript backupService;


### PR DESCRIPTION
distinguishes the description for contract `databasebackup` from that of contract `backup`.
