### PR TITLE
Use forked login_oidc with Nextcloud

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -1102,9 +1102,21 @@ in
           }
         ];
 
-        services.nextcloud.extraApps = {
-          inherit (nextcloudApps) oidc_login;
-        };
+        services.nextcloud.extraApps =
+          if (cfg.version == 31) then
+            {
+              inherit (nextcloudApps) oidc_login;
+            }
+          else
+            {
+              oidc_login = pkgs.fetchNextcloudApp {
+                appName = "oidc_login";
+                sha256 = "sha256-nI5HSzwlcjWOpo7eWjgzm3BE9rXnqKSC42KSP2LGfdE=";
+                url = "https://github.com/toony/nextcloud-oidc-login/archive/refs/heads/bugfix/319-nextcloud32-compat.tar.gz";
+                appVersion = "3.2.2-nextcloud32-compat";
+                license = "agpl3Plus";
+              };
+            };
 
         systemd.services.nextcloud-setup-pre = {
           wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
Closes #605 

Not my proudest PR but does the job. For Nextcloud 31, use the plugin from upstream Nix. For Nextcloud 32, use `fetchNextcloudApp` with fork hacked to work on 32 as the upstream is a bit slow to react.