### PR TITLE
fix: add OIDC scopes to Jellyfin service

### DIFF
--- a/modules/services/jellyfin.nix
+++ b/modules/services/jellyfin.nix
@@ -483,6 +483,7 @@ in
                       <string>groups</string>
                     </OidScopes>
                     <CanonicalLinks />
+                    <DisablePushedAuthorization>true</DisablePushedAuthorization>
                   </PluginConfiguration>
                 </value>
               </item>
@@ -732,7 +733,10 @@ in
         require_pkce = true;
         pkce_challenge_method = "S256";
         userinfo_signed_response_alg = "none";
+        # Jellyfin SSO plugin uses client_secret_post for token exchange
         token_endpoint_auth_method = "client_secret_post";
+        # Required OIDC scopes for Authelia to return group claims
+        scopes = ["openid" "profile" "email" "groups"];
       }
     ];
   };


### PR DESCRIPTION
Also adds
<DisabledPushedAuthorization>true</DisablePushedAuthorization>, as otherwise I get "Error preparing login: Unauthorized - Failed to push authorization parameters"