### PR TITLE
firefly-iii: allow admin group access

### DIFF
--- a/modules/services/firefly-iii.nix
+++ b/modules/services/firefly-iii.nix
@@ -407,7 +407,10 @@ in
               {
                 domain = "${cfg.subdomain}.${cfg.domain}";
                 policy = cfg.sso.authorization_policy;
-                subject = [ "group:${cfg.ldap.userGroup}" ];
+                subject = [
+                  "group:${cfg.ldap.userGroup}"
+                  "group:${cfg.ldap.adminGroup}"
+                ];
               }
             ];
           }


### PR DESCRIPTION
I think this is needed to allow users that are only members of firefly-iii_admin access to the main firefly service.

Not sure how _user vs _admin is intended to be used though, I usually use *either* _admin or _user.