### PR TITLE
authelia: revert do not use dots in systemd service name

### DIFF
--- a/modules/blocks/authelia.nix
+++ b/modules/blocks/authelia.nix
@@ -11,7 +11,7 @@ let
   cfg = config.shb.authelia;
   opt = options.shb.authelia;
 
-  fqdn = builtins.replaceStrings [ "." ] [ "_" ] "${cfg.subdomain}.${cfg.domain}";
+  fqdn = "${cfg.subdomain}.${cfg.domain}";
   fqdnWithPort = if isNull cfg.port then fqdn else "${fqdn}:${toString cfg.port}";
 
   autheliaCfg = config.services.authelia.instances.${fqdn};

--- a/test/blocks/authelia.nix
+++ b/test/blocks/authelia.nix
@@ -133,7 +133,7 @@ in
 
         def tests():
             machine.wait_for_unit("lldap.service")
-            machine.wait_for_unit("authelia-authelia_machine_com.target")
+            machine.wait_for_unit("authelia-authelia.machine.com.target")
             machine.wait_for_open_port(9091)
 
             endpoints = json.loads(machine.succeed("curl -s http://machine.com/.well-known/openid-configuration"))

--- a/test/common.nix
+++ b/test/common.nix
@@ -75,9 +75,7 @@ let
     ''
     + lib.strings.concatMapStrings (s: ''server.wait_for_unit("${s}")'' + "\n") (
       waitForServices args
-      ++ (lib.optionals autheliaEnabled [
-        "authelia-auth_${builtins.replaceStrings [ "." ] [ "_" ] cfg.domain}.service"
-      ])
+      ++ (lib.optionals autheliaEnabled [ "authelia-auth.${cfg.domain}.service" ])
       ++ (lib.optionals lldapEnabled [ "lldap.service" ])
     )
     + lib.strings.concatMapStrings (p: ''server.wait_for_open_port(${toString p})'' + "\n") (
@@ -232,7 +230,6 @@ in
         baseImports
         ../modules/blocks/hardcodedsecret.nix
         ../modules/blocks/nginx.nix
-        ../modules/blocks/postgresql.nix
       ];
       config = {
         # HTTP(s) server port.


### PR DESCRIPTION
The issue is the fqdn is used to setup the nginx virtual host