### PR TITLE
update nixpkgs to 4d72182edd899c02ec2018b784adab36bb105ddb

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1778628726,
+        "narHash": "sha256-02q3d1opG/P6Ogxv2rISwj2LOx1H7BmaEHk2JVh2wpw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "bea8623f390c15be9e1a9f674126cedf6dafa576",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778628726,
-        "narHash": "sha256-02q3d1opG/P6Ogxv2rISwj2LOx1H7BmaEHk2JVh2wpw=",
+        "lastModified": 1778530773,
+        "narHash": "sha256-IXbXo8oMTOHUitx3/hgUqJZS55HUcuBXn49NcyGWN28=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bea8623f390c15be9e1a9f674126cedf6dafa576",
+        "rev": "4d72182edd899c02ec2018b784adab36bb105ddb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/da5ad661ba4e5ef59ba743f0d112cbc30e474f32...d233902339c02a9c334e7e593de68855ad26c4cb ❌
 - https://github.com/NixOS/nixpkgs/compare/da5ad661ba4e5ef59ba743f0d112cbc30e474f32...bea8623f390c15be9e1a9f674126cedf6dafa576 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/da5ad661ba4e5ef59ba743f0d112cbc30e474f32...4d72182edd899c02ec2018b784adab36bb105ddb (bisected in the past)