### PR TITLE
Use Python instead of `sed` for secret substitution and use escapeShellArg

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,15 +80,11 @@ let
 
         generatedReplacements = map genReplacement replacements;
 
-        writeSecretFiles = concatMapStringsSep "\n" (pattern: ''
-          printf '%s' "${pattern.value}" > "$tmpDir"/${escapeShellArg ("secret-" + pattern.name)}
-        '') generatedReplacements;
-
         replaceCommands = concatMapStringsSep "\n" (pattern: ''
           ${replaceScript} \
             --file ${escapeShellArg resultPath} \
             --marker ${escapeShellArg pattern.name} \
-            --secret-file "$tmpDir"/${escapeShellArg ("secret-" + pattern.name)}
+            --replacement "${pattern.value}"
         '') generatedReplacements;
 
         replaceScript = pkgs.writers.writePython3 "replace-secret" { } ''
@@ -100,14 +96,13 @@ let
               parser = argparse.ArgumentParser()
               parser.add_argument("--file", required=True, type=pathlib.Path)
               parser.add_argument("--marker", required=True)
-              parser.add_argument("--secret-file", required=True, type=pathlib.Path)
+              parser.add_argument("--replacement", required=True)
               return parser.parse_args()
 
 
           args = parse_args()
           content = args.file.read_text()
-          secret = args.secret_file.read_text()
-          args.file.write_text(content.replace(args.marker, secret))
+          args.file.write_text(content.replace(args.marker, args.replacement))
         '';
 
         replaceCmd =
@@ -115,10 +110,7 @@ let
             "cat ${escapeShellArg templatePath} > ${escapeShellArg resultPath}"
           else
             ''
-              tmpDir=$(mktemp -d)
-              trap 'rm -rf "$tmpDir"' EXIT
               cat ${escapeShellArg templatePath} > ${escapeShellArg resultPath}
-              ${writeSecretFiles}
               ${replaceCommands}
             '';
       in

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -59,9 +59,7 @@ let
           }:
           if isNull transform then x: x else transform;
       in
-      lib.attrsets.nameValuePair (secretName secret.name) (
-        (t secret) "$(cat ${toString secret.source})"
-      );
+      lib.attrsets.nameValuePair (secretName secret.name) ((t secret) "$(cat ${toString secret.source})");
 
     replaceSecretsScript =
       {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,7 +1,7 @@
 { pkgs, lib }:
 let
   inherit (builtins) isAttrs hasAttr;
-  inherit (lib) any concatMapStringsSep concatStringsSep;
+  inherit (lib) any concatMapStringsSep concatStringsSep escapeShellArg;
   shb = rec {
     # Replace secrets in a file.
     # - userConfig is an attrset that will produce a config file.
@@ -54,7 +54,9 @@ let
           }:
           if isNull transform then x: x else transform;
       in
-      lib.attrsets.nameValuePair (secretName secret.name) ((t secret) "$(cat ${toString secret.source})");
+      lib.attrsets.nameValuePair
+        (secretName secret.name)
+        ((t secret) "$(cat ${escapeShellArg (toString secret.source)})");
 
     replaceSecretsScript =
       {
@@ -76,11 +78,58 @@ let
           pattern: "cat ${pattern.source} > /dev/null"
         ) replacements;
 
-        sedPatterns = concatMapStringsSep " " (pattern: "-e \"s|${pattern.name}|${pattern.value}|\"") (
-          map genReplacement replacements
-        );
+        generatedReplacements = map genReplacement replacements;
 
-        sedCmd = if replacements == [ ] then "cat" else "${pkgs.gnused}/bin/sed ${sedPatterns}";
+        writeSecretFiles = concatMapStringsSep "\n" (pattern: ''
+          printf '%s' "${pattern.value}" > "$tmpDir/secret-${pattern.name}"
+        '') generatedReplacements;
+
+        replacementArgs = concatMapStringsSep " " (
+          pattern: "${escapeShellArg pattern.name} \"$tmpDir/secret-${pattern.name}\""
+        ) generatedReplacements;
+
+        replaceScript = pkgs.writers.writePython3 "replace-secrets" { } ''
+          import argparse
+          import pathlib
+
+
+          def parse_args() -> argparse.Namespace:
+              parser = argparse.ArgumentParser()
+              parser.add_argument("template_path", type=pathlib.Path)
+              parser.add_argument("result_path", type=pathlib.Path)
+              parser.add_argument(
+                  "replacements",
+                  nargs="*",
+                  help="marker/file pairs: MARKER SECRET_FILE [MARKER SECRET_FILE ...]",
+              )
+              args = parser.parse_args()
+
+              if len(args.replacements) % 2 != 0:
+                  parser.error("replacements must be marker/file pairs")
+
+              return args
+
+
+          args = parse_args()
+          content = args.template_path.read_text()
+
+          for marker, secret_path in zip(args.replacements[0::2], args.replacements[1::2]):
+              secret = pathlib.Path(secret_path).read_text()
+              content = content.replace(marker, secret)
+
+          args.result_path.write_text(content)
+        '';
+
+        replaceCmd =
+          if replacements == [ ] then
+            "cat ${escapeShellArg templatePath} > ${escapeShellArg resultPath}"
+          else
+            ''
+              tmpDir=$(mktemp -d)
+              trap 'rm -rf "$tmpDir"' EXIT
+              ${writeSecretFiles}
+              ${replaceScript} ${escapeShellArg templatePath} ${escapeShellArg resultPath} ${replacementArgs}
+            '';
       in
       ''
         set -euo pipefail
@@ -96,7 +145,7 @@ let
         chown ${user} ${resultPath}
       '')
       + ''
-        ${sedCmd} ${templatePath} > ${resultPath}
+        ${replaceCmd}
         chmod ${permissions} ${resultPath}
       '';
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -81,43 +81,33 @@ let
         generatedReplacements = map genReplacement replacements;
 
         writeSecretFiles = concatMapStringsSep "\n" (pattern: ''
-          printf '%s' "${pattern.value}" > "$tmpDir/secret-${pattern.name}"
+          printf '%s' "${pattern.value}" > "$tmpDir"/${escapeShellArg ("secret-" + pattern.name)}
         '') generatedReplacements;
 
-        replacementArgs = concatMapStringsSep " " (
-          pattern: "${escapeShellArg pattern.name} \"$tmpDir/secret-${pattern.name}\""
-        ) generatedReplacements;
+        replaceCommands = concatMapStringsSep "\n" (pattern: ''
+          ${replaceScript} \
+            --file ${escapeShellArg resultPath} \
+            --marker ${escapeShellArg pattern.name} \
+            --secret-file "$tmpDir"/${escapeShellArg ("secret-" + pattern.name)}
+        '') generatedReplacements;
 
-        replaceScript = pkgs.writers.writePython3 "replace-secrets" { } ''
+        replaceScript = pkgs.writers.writePython3 "replace-secret" { } ''
           import argparse
           import pathlib
 
 
           def parse_args() -> argparse.Namespace:
               parser = argparse.ArgumentParser()
-              parser.add_argument("template_path", type=pathlib.Path)
-              parser.add_argument("result_path", type=pathlib.Path)
-              parser.add_argument(
-                  "replacements",
-                  nargs="*",
-                  help="marker/file pairs: MARKER SECRET_FILE [MARKER SECRET_FILE ...]",
-              )
-              args = parser.parse_args()
-
-              if len(args.replacements) % 2 != 0:
-                  parser.error("replacements must be marker/file pairs")
-
-              return args
+              parser.add_argument("--file", required=True, type=pathlib.Path)
+              parser.add_argument("--marker", required=True)
+              parser.add_argument("--secret-file", required=True, type=pathlib.Path)
+              return parser.parse_args()
 
 
           args = parse_args()
-          content = args.template_path.read_text()
-
-          for marker, secret_path in zip(args.replacements[0::2], args.replacements[1::2]):
-              secret = pathlib.Path(secret_path).read_text()
-              content = content.replace(marker, secret)
-
-          args.result_path.write_text(content)
+          content = args.file.read_text()
+          secret = args.secret_file.read_text()
+          args.file.write_text(content.replace(args.marker, secret))
         '';
 
         replaceCmd =
@@ -127,8 +117,9 @@ let
             ''
               tmpDir=$(mktemp -d)
               trap 'rm -rf "$tmpDir"' EXIT
+              cat ${escapeShellArg templatePath} > ${escapeShellArg resultPath}
               ${writeSecretFiles}
-              ${replaceScript} ${escapeShellArg templatePath} ${escapeShellArg resultPath} ${replacementArgs}
+              ${replaceCommands}
             '';
       in
       ''

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,7 +1,12 @@
 { pkgs, lib }:
 let
   inherit (builtins) isAttrs hasAttr;
-  inherit (lib) any concatMapStringsSep concatStringsSep escapeShellArg;
+  inherit (lib)
+    any
+    concatMapStringsSep
+    concatStringsSep
+    escapeShellArg
+    ;
   shb = rec {
     # Replace secrets in a file.
     # - userConfig is an attrset that will produce a config file.
@@ -54,9 +59,9 @@ let
           }:
           if isNull transform then x: x else transform;
       in
-      lib.attrsets.nameValuePair
-        (secretName secret.name)
-        ((t secret) "$(cat ${escapeShellArg (toString secret.source)})");
+      lib.attrsets.nameValuePair (secretName secret.name) (
+        (t secret) "$(cat ${escapeShellArg (toString secret.source)})"
+      );
 
     replaceSecretsScript =
       {

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,13 +80,6 @@ let
 
         generatedReplacements = map genReplacement replacements;
 
-        replaceCommands = concatMapStringsSep "\n" (pattern: ''
-          ${replaceScript} \
-            --file ${escapeShellArg resultPath} \
-            --marker ${escapeShellArg pattern.name} \
-            --replacement "${pattern.value}"
-        '') generatedReplacements;
-
         replaceScript = pkgs.writers.writePython3 "replace-secret" { } ''
           import argparse
           import pathlib
@@ -104,6 +97,13 @@ let
           content = args.file.read_text()
           args.file.write_text(content.replace(args.marker, args.replacement))
         '';
+
+        replaceCommands = concatMapStringsSep "\n" (pattern: ''
+          ${replaceScript} \
+            --file ${escapeShellArg resultPath} \
+            --marker ${escapeShellArg pattern.name} \
+            --replacement "${pattern.value}"
+        '') generatedReplacements;
 
         replaceCmd =
           if replacements == [ ] then

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -60,7 +60,7 @@ let
           if isNull transform then x: x else transform;
       in
       lib.attrsets.nameValuePair (secretName secret.name) (
-        (t secret) "$(cat ${escapeShellArg (toString secret.source)})"
+        (t secret) "$(cat ${toString secret.source})"
       );
 
     replaceSecretsScript =


### PR DESCRIPTION
The original `sed` version was failing for multiline secrets.

Fixes https://github.com/ibizaman/selfhostblocks/issues/719.

Unrelatedly, the `transform` parameter on secrets probably needs to be reconsidered. It is a shell command, and shell is extremely brittle, as evidenced by this PR.

If not for the `transform` parameter, this PR would have taken me a fifth of the time it actually took.