### PR TITLE
test(open-webui): assert SSO session instead of login toast

### DIFF
--- a/test/services/open-webui.nix
+++ b/test/services/open-webui.nix
@@ -101,7 +101,8 @@ let
               "page.get_by_role('button', name=re.compile('Accept')).click()"
               "expect(page.get_by_text(re.compile('[Ii]ncorrect'))).not_to_be_visible()"
               "expect(page.get_by_role('button', name=re.compile('Sign In'))).not_to_be_visible()"
-              "expect(page.get_by_text('logged in')).to_be_visible(timeout=20000)"
+              "expect(page).to_have_url(re.compile('https://o.example.com/$'), timeout=20000)"
+              "assert page.evaluate(\"async () => { const r = await fetch('/api/v1/auths/'); if (!r.ok) return false; const u = await r.json(); return u.email === 'alice@example.com'; }\")"
             ];
           }
           {
@@ -118,7 +119,8 @@ let
               "page.get_by_role('button', name=re.compile('Accept')).click()"
               "expect(page.get_by_text(re.compile('[Ii]ncorrect'))).not_to_be_visible()"
               "expect(page.get_by_role('button', name=re.compile('Sign In'))).not_to_be_visible()"
-              "expect(page.get_by_text('logged in')).to_be_visible(timeout=20000)"
+              "expect(page).to_have_url(re.compile('https://o.example.com/$'), timeout=20000)"
+              "assert page.evaluate(\"async () => { const r = await fetch('/api/v1/auths/'); if (!r.ok) return false; const u = await r.json(); return u.email === 'bob@example.com'; }\")"
             ];
           }
           {


### PR DESCRIPTION
Open WebUI redirects from /auth to / after OIDC login and briefly shows the "You're now logged in" toast during that transition. The toast is not a stable post-login signal, so the VM test can fail even though SSO succeeded.

Wait for the final root URL and verify the authenticated Open WebUI session through /api/v1/auths/ instead. This keeps the test focused on the expected SSO outcome while avoiding the transient UI race.