### PR TITLE
Restart deluged on failure in tests

### DIFF
--- a/test/services/deluge.nix
+++ b/test/services/deluge.nix
@@ -108,6 +108,11 @@ let
         request = config.shb.deluge.localclientPassword.request;
         settings.content = "localpw";
       };
+
+      systemd.services.deluged.serviceConfig = {
+        Restart = lib.mkForce "on-failure";
+        RestartSec = "1s";
+      };
     };
 
   clientLogin =

--- a/test/services/deluge.nix
+++ b/test/services/deluge.nix
@@ -25,6 +25,14 @@ let
       ''
         print(${node.name}.succeed('journalctl -n100 -u deluged'))
         print(${node.name}.succeed('systemctl status deluged'))
+        ${node.name}.succeed("""
+          restarts="$(systemctl show deluged.service -P NRestarts)"
+          if [ "$restarts" -gt 1 ]; then
+            systemctl status deluged.service --no-pager
+            journalctl -u deluged.service -b --no-pager
+            exit 1
+          fi
+        """)
         print(${node.name}.succeed('systemctl status delugeweb'))
 
         with subtest("web connect"):
@@ -109,9 +117,16 @@ let
         settings.content = "localpw";
       };
 
-      systemd.services.deluged.serviceConfig = {
-        Restart = lib.mkForce "on-failure";
-        RestartSec = "1s";
+      systemd.services.deluged = {
+        unitConfig = {
+          StartLimitIntervalSec = "30s";
+          StartLimitBurst = 2;
+        };
+
+        serviceConfig = {
+          Restart = lib.mkForce "on-failure";
+          RestartSec = "1s";
+        };
       };
     };
 


### PR DESCRIPTION
Running

```sh
nix build .#checks.x86_64-linux.vm_deluge_sso --max-jobs 1 --cores 1
```

`deluged` sometimes segfaults: https://gist.github.com/dniku/5056689d9191e839e39d4c7b3fbf6410

Fixing this does not seem in scope for SHB.