### PR TITLE
Extract Jellyfin test extraScript into commonExtraScript and prepend it in LDAP test

### DIFF
--- a/test/services/jellyfin.nix
+++ b/test/services/jellyfin.nix
@@ -5,6 +5,36 @@ let
   adminUser = "jellyfin2";
   adminPassword = "admin";
 
+  commonExtraScript =
+    { node, ... }:
+    ''
+      server.wait_until_succeeds("journalctl --since -1m --unit jellyfin --grep 'Startup complete'")
+      headers = unline_with(" ", """
+          -H 'Content-Type: application/json'
+          -H 'Authorization: MediaBrowser Client="Android TV", Device="Nvidia Shield", DeviceId="ZQ9YQHHrUzk24vV", Version="0.15.3"'
+      """)
+      import time
+      with subtest("api login success"):
+          ok = False
+          for i in range(1, 5):
+              response = curl(client, """{"code":%{response_code}}""", "${node.config.test.proto_fqdn}/Users/AuthenticateByName",
+                  data="""{"Username": "${adminUser}", "Pw": "${adminPassword}"}""",
+                  extra=headers)
+              if response['code'] == 200:
+                  ok = True
+                  break
+              time.sleep(5)
+          if not ok:
+              raise Exception(f"Expected success, got: {response['code']}")
+
+      with subtest("api login failure"):
+          response = curl(client, """{"code":%{response_code}}""", "${node.config.test.proto_fqdn}/Users/AuthenticateByName",
+              data="""{"Username": "${adminUser}", "Pw": "badpassword"}""",
+              extra=headers)
+          if response['code'] != 401:
+              raise Exception(f"Expected failure, got: {response['code']}")
+    '';
+
   commonTestScript = shb.test.mkScripts {
     hasSSL = { node, ... }: !(isNull node.config.shb.jellyfin.ssl);
     waitForServices =
@@ -27,35 +57,7 @@ let
           status = 401;
         }
       ];
-    extraScript =
-      { node, ... }:
-      ''
-        server.wait_until_succeeds("journalctl --since -1m --unit jellyfin --grep 'Startup complete'")
-        headers = unline_with(" ", """
-            -H 'Content-Type: application/json'
-            -H 'Authorization: MediaBrowser Client="Android TV", Device="Nvidia Shield", DeviceId="ZQ9YQHHrUzk24vV", Version="0.15.3"'
-        """)
-        import time
-        with subtest("api login success"):
-            ok = False
-            for i in range(1, 5):
-                response = curl(client, """{"code":%{response_code}}""", "${node.config.test.proto_fqdn}/Users/AuthenticateByName",
-                    data="""{"Username": "${adminUser}", "Pw": "${adminPassword}"}""",
-                    extra=headers)
-                if response['code'] == 200:
-                    ok = True
-                    break
-                time.sleep(5)
-            if not ok:
-                raise Exception(f"Expected success, got: {response['code']}")
-
-        with subtest("api login failure"):
-            response = curl(client, """{"code":%{response_code}}""", "${node.config.test.proto_fqdn}/Users/AuthenticateByName",
-                data="""{"Username": "${adminUser}", "Pw": "badpassword"}""",
-                extra=headers)
-            if response['code'] != 401:
-                raise Exception(f"Expected failure, got: {response['code']}")
-      '';
+    extraScript = commonExtraScript;
   };
 
   basic =
@@ -452,12 +454,13 @@ in
 
     testScript = commonTestScript.access.override {
       extraScript =
-        {
+        args@{
           node,
           ...
         }:
+        (commonExtraScript args)
         # I have no idea why the LDAP Authentication_19.0.0.0 plugin disappears.
-        ''
+        + ''
           r = server.execute('cat "${node.config.services.jellyfin.dataDir}/plugins/LDAP Authentication_19.0.0.0/meta.json"')
           if r[0] != 0:
               print("meta.json for plugin LDAP Authentication_19.0.0.0 not found")


### PR DESCRIPTION
`commonTestScript.access.override` replaces the full extraScript, and in particular drops:

```
server.wait_until_succeeds("journalctl --since -1m --unit jellyfin --grep 'Startup complete'")
```

https://github.com/ibizaman/selfhostblocks/actions/runs/27462763816/job/81262609484?pr=731 shows the symptoms:

* https://github.com/ibizaman/selfhostblocks/actions/runs/27462763816/job/81262609484?pr=731#step:5:7163 logs `Login from client` (defined in https://github.com/ibizaman/selfhostblocks/blob/8871b9435b599e24a8d8a1cf712d7104912e22a7/test/common.nix#L166) at timestamp `2026-06-14T08:34:06.7507323Z` (visible in the raw logs)
* https://github.com/ibizaman/selfhostblocks/actions/runs/27462763816/job/81262609484?pr=731#step:5:7167 is the first request from Firefox at timestamp `2026-06-14T08:34:18.2868336Z`, so the attempt to fill in the username starts around there, with a 30-second timeout
*  https://github.com/ibizaman/selfhostblocks/actions/runs/27462763816/job/81262609484?pr=731#step:5:7577 logs `Main: Startup complete 0:01:00.1813498` at timestamp `2026-06-14T08:34:51.1325282Z`, 45 seconds after test starts, and 33 seconds after the first Firefox request. This gives just 3 seconds for Firefox to get to the point when it starts waiting for username to appear.

Work around by explicitly prepending the full `extraScript` to the override.