### PR TITLE
update nixpkgs to abd1ea17fdbedd48cbca770847b39e3a7a09ab5b

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778530773,
-        "narHash": "sha256-IXbXo8oMTOHUitx3/hgUqJZS55HUcuBXn49NcyGWN28=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d72182edd899c02ec2018b784adab36bb105ddb",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779810870,
-        "narHash": "sha256-C3dJW93/MGghgYkrTqS0CJcs7EfRMG8+5dgzAabJQHo=",
+        "lastModified": 1779106008,
+        "narHash": "sha256-69DUmukrvXPNjSgtI1TmsKQ5TwNlclhMDcIWbimdSGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f7b4a3918b4d5c61788a8705ad117bf513baa70",
+        "rev": "abd1ea17fdbedd48cbca770847b39e3a7a09ab5b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1779810870,
+        "narHash": "sha256-C3dJW93/MGghgYkrTqS0CJcs7EfRMG8+5dgzAabJQHo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "8f7b4a3918b4d5c61788a8705ad117bf513baa70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/4d72182edd899c02ec2018b784adab36bb105ddb...9ae611a455b90cf061d8f332b977e387bda8e1ca ❌
 - https://github.com/NixOS/nixpkgs/compare/4d72182edd899c02ec2018b784adab36bb105ddb...8f7b4a3918b4d5c61788a8705ad117bf513baa70 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/4d72182edd899c02ec2018b784adab36bb105ddb...abd1ea17fdbedd48cbca770847b39e3a7a09ab5b (bisected in the past)