### PR TITLE
Change credentialsFile to environmentFile in ssl.nix

### DIFF
--- a/modules/blocks/ssl.nix
+++ b/modules/blocks/ssl.nix
@@ -551,7 +551,7 @@ in
                     // lib.optionalAttrs (certCfg.dnsProvider != null) {
                       inherit (certCfg) dnsProvider dnsResolver;
                       inherit (certCfg) group reloadServices;
-                      credentialsFile = certCfg.credentialsFile;
+                      environmentFile = certCfg.credentialsFile;
                     };
                   }
                 ]


### PR DESCRIPTION
This option was renamed in https://github.com/NixOS/nixpkgs/pull/244477, and the alias was deleted in https://github.com/NixOS/nixpkgs/pull/512107.

There are currently no tests to catch the regression.