### PR TITLE
Fix Open WebUI tests in offline mode

### DIFF
--- a/test/services/open-webui.nix
+++ b/test/services/open-webui.nix
@@ -35,7 +35,13 @@ let
         inherit (config.test) subdomain domain;
       };
       # Speeds up tests because models can't be downloaded anyway and that leads to retries.
-      services.open-webui.environment.OFFLINE_MODE = "true";
+      services.open-webui.environment = {
+        OFFLINE_MODE = "true";
+        BYPASS_EMBEDDING_AND_RETRIEVAL = "true";
+        RAG_EMBEDDING_ENGINE = "ollama";
+        RAG_EMBEDDING_MODEL = "dummy";
+        RAG_OLLAMA_BASE_URL = "http://127.0.0.1:9";
+      };
 
       networking.hosts = {
         "127.0.0.1" = [ "${config.test.subdomain}.${config.test.domain}" ];


### PR DESCRIPTION
Open WebUI 0.9.6 still initializes its embedding function during startup, even when `OFFLINE_MODE=true` and `BYPASS_EMBEDDING_AND_RETRIEVAL=true`. With `OFFLINE_MODE=true` and no cached `SentenceTransformer` model, startup failed with:

```
ValueError: No embedding model is loaded. Set RAG_EMBEDDING_MODEL to a valid SentenceTransformer model name, or configure an external RAG_EMBEDDING_ENGINE (ollama, openai, azure_openai).
```

See: https://github.com/open-webui/open-webui/blob/02dc3e689ceac915a870b373318b99c029ddf603/backend/open_webui/retrieval/utils.py#L931-L935

Configure the tests to use a dummy Ollama embedding endpoint so startup does not try to load or download a local embedding model. The endpoint is not meant to be contacted by these tests; it only keeps startup on the external embedding configuration path.