### PR TITLE
backup: re-use existing wrapper for restic and borgbackup0

### DIFF
--- a/modules/blocks/borgbackup.nix
+++ b/modules/blocks/borgbackup.nix
@@ -154,6 +154,8 @@ let
 
   repoSlugName = name: builtins.replaceStrings [ "/" ":" ] [ "_" "_" ] (removePrefix "/" name);
   fullName = name: repository: "borgbackup-job-${name}_${repoSlugName repository.path}";
+  scriptName =
+    name: repository: config.services.borgbackup.jobs."${name}_${repoSlugName repository.path}".wrapper;
 in
 {
   imports = [
@@ -429,44 +431,21 @@ in
           mkMerge (flatten (mapAttrsToList mkSettings (enabledInstances // enabledDatabases)));
       }
       {
-        systemd.services =
-          let
-            mkEnv =
-              name: instance:
-              nameValuePair "${fullName name instance.settings.repository}_restore_gen" {
-                enable = true;
-                wantedBy = [ "multi-user.target" ];
-                serviceConfig.Type = "oneshot";
-                script = (
-                  shb.replaceSecrets {
-                    userConfig = instance.settings.repository.secrets // {
-                      BORG_PASSCOMMAND = ''"cat ${instance.settings.passphrase.result.path}"'';
-                      BORG_REPO = instance.settings.repository.path;
-                    };
-                    resultPath = "/run/secrets_borgbackup_env/${fullName name instance.settings.repository}";
-                    generator = shb.toEnvVar;
-                    user = instance.request.user;
-                  }
-                );
-              };
-          in
-          listToAttrs (flatten (mapAttrsToList mkEnv (cfg.instances // cfg.databases)));
-      }
-      {
         environment.systemPackages =
           let
             mkBorgBackupBinary =
-              name: instance:
+              n: instance:
+              let
+                sname = scriptName n instance.settings.repository;
+                fname = fullName n instance.settings.repository;
+              in
               shb.contracts.backup.mkRestoreScript {
-                name = fullName name instance.settings.repository;
+                name = fname;
                 user = instance.request.user;
-                sudoPreserveEnvs = [
-                  "BORG_REPO"
-                  "BORG_PASSCOMMAND"
-                ];
-                secretsFile = "/run/secrets_borgbackup_env/${fullName name instance.settings.repository}";
-                restoreCmd = ''(cd / && ${pkgs.borgbackup}/bin/borg extract \"$BORG_REPO::$snapshot\")'';
-                listCmd = ''if [ -e \"$BORG_REPO/data\" ]; then borg list --short \"$BORG_REPO\"; fi'';
+                backupCmd = "systemctl start --wait ${fname}";
+                restoreCmd = ''(cd / && exec ${sname} extract "::$snapshot")'';
+                listCmd = "exec ${sname} list --short";
+                execCmd = "exec ${sname}";
               };
           in
           flatten (mapAttrsToList mkBorgBackupBinary cfg.instances);
@@ -475,17 +454,18 @@ in
         environment.systemPackages =
           let
             mkBorgBackupBinary =
-              name: instance:
+              n: instance:
+              let
+                sname = scriptName n instance.settings.repository;
+                fname = fullName n instance.settings.repository;
+              in
               shb.contracts.backup.mkRestoreScript {
-                name = fullName name instance.settings.repository;
+                name = fname;
                 user = instance.request.user;
-                sudoPreserveEnvs = [
-                  "BORG_REPO"
-                  "BORG_PASSCOMMAND"
-                ];
-                secretsFile = "/run/secrets_borgbackup_env/${fullName name instance.settings.repository}";
-                restoreCmd = ''${pkgs.borgbackup}/bin/borg extract \"$BORG_REPO::$snapshot\" --stdout | ${instance.request.restoreCmd}'';
-                listCmd = ''if [ -e \"$BORG_REPO/data\" ]; then borg list --short \"$BORG_REPO\"; fi'';
+                backupCmd = "systemctl start --wait ${fname}";
+                restoreCmd = ''exec ${sname} extract "::$snapshot" --stdout | ${instance.request.restoreCmd}'';
+                listCmd = "exec ${sname} list --short";
+                execCmd = "exec ${sname}";
               };
           in
           flatten (mapAttrsToList mkBorgBackupBinary cfg.databases);

--- a/modules/blocks/postgresql.nix
+++ b/modules/blocks/postgresql.nix
@@ -77,7 +77,7 @@ in
           '';
 
           restoreCmd = ''
-            ${pkgs.gzip}/bin/gunzip | ${pkgs.postgresql}/bin/psql postgres
+            ${pkgs.gzip}/bin/gunzip | sudo -u postgres ${pkgs.postgresql}/bin/psql
           '';
         };
       };

--- a/modules/blocks/restic.nix
+++ b/modules/blocks/restic.nix
@@ -145,6 +145,7 @@ let
 
   repoSlugName = name: builtins.replaceStrings [ "/" ":" ] [ "_" "_" ] (removePrefix "/" name);
   fullName = name: repository: "restic-backups-${name}_${repoSlugName repository.path}";
+  scriptName = name: repository: "restic-${name}_${repoSlugName repository.path}";
 in
 {
   imports = [
@@ -292,6 +293,7 @@ in
                 passwordFile = toString instance.settings.passphrase.result.path;
 
                 initialize = true;
+                createWrapper = true;
 
                 inherit (instance.settings.repository) timerConfig;
 
@@ -332,6 +334,7 @@ in
                 passwordFile = toString instance.settings.passphrase.result.path;
 
                 initialize = true;
+                createWrapper = true;
 
                 inherit (instance.settings.repository) timerConfig;
 
@@ -406,50 +409,21 @@ in
           mkMerge (flatten (mapAttrsToList mkSettings (enabledInstances // enabledDatabases)));
       }
       {
-        systemd.services =
-          let
-            mkEnv =
-              name: instance:
-              nameValuePair "${fullName name instance.settings.repository}_restore_gen" {
-                enable = true;
-                wantedBy = [ "multi-user.target" ];
-                # Purposely not a oneshot systemd service otherwise
-                # the service waits on the completion the backup before deactivating.
-                # This seems like a nice property at first but there is one annoying
-                # edge case when deploying. If a backup job somehow is started when
-                # the deploy happens, the deploy will wait on the service to finish
-                # before considering the deploy done. And worse, it will consider the
-                # deploy as failed if the backup fails, which is not what you want.
-                script = (
-                  shb.replaceSecrets {
-                    userConfig = instance.settings.repository.secrets // {
-                      RESTIC_PASSWORD_FILE = toString instance.settings.passphrase.result.path;
-                      RESTIC_REPOSITORY = instance.settings.repository.path;
-                    };
-                    resultPath = "/run/secrets_restic_env/${fullName name instance.settings.repository}";
-                    generator = shb.toEnvVar;
-                    user = instance.request.user;
-                  }
-                );
-              };
-          in
-          listToAttrs (flatten (mapAttrsToList mkEnv (cfg.instances // cfg.databases)));
-      }
-      {
         environment.systemPackages =
           let
             mkResticBinary =
-              name: instance:
+              n: instance:
+              let
+                sname = scriptName n instance.settings.repository;
+                fname = fullName n instance.settings.repository;
+              in
               shb.contracts.backup.mkRestoreScript {
-                name = fullName name instance.settings.repository;
+                name = fname;
                 user = instance.request.user;
-                sudoPreserveEnvs = [
-                  "RESTIC_REPOSITORY"
-                  "RESTIC_PASSWORD_FILE"
-                ];
-                secretsFile = "/run/secrets_restic_env/${fullName name instance.settings.repository}";
-                restoreCmd = ''${pkgs.restic}/bin/restic restore \"$snapshot\" --target /'';
-                listCmd = ''if [ -e \"$RESTIC_REPOSITORY/index\" ]; then ${pkgs.restic}/bin/restic snapshots --json | ${pkgs.jq}/bin/jq '.[].id'; fi'';
+                backupCmd = "systemctl start --wait ${fname}";
+                restoreCmd = ''exec ${sname} restore "$snapshot" --target /'';
+                listCmd = "exec ${sname} snapshots --json | ${pkgs.jq}/bin/jq -r '.[].id' ";
+                execCmd = "exec ${sname}";
               };
           in
           flatten (mapAttrsToList mkResticBinary cfg.instances);
@@ -458,17 +432,18 @@ in
         environment.systemPackages =
           let
             mkResticBinary =
-              name: instance:
+              n: instance:
+              let
+                sname = scriptName n instance.settings.repository;
+                fname = fullName n instance.settings.repository;
+              in
               shb.contracts.backup.mkRestoreScript {
-                name = fullName name instance.settings.repository;
+                name = fname;
                 user = instance.request.user;
-                sudoPreserveEnvs = [
-                  "RESTIC_REPOSITORY"
-                  "RESTIC_PASSWORD_FILE"
-                ];
-                secretsFile = "/run/secrets_restic_env/${fullName name instance.settings.repository}";
-                restoreCmd = ''${pkgs.restic}/bin/restic dump \"$snapshot\" ${instance.request.backupName} | ${instance.request.restoreCmd}'';
-                listCmd = ''if [ -e \"$RESTIC_REPOSITORY/index\" ]; then ${pkgs.restic}/bin/restic snapshots --json | ${pkgs.jq}/bin/jq '.[].id'; fi'';
+                backupCmd = "systemctl start --wait ${fname}";
+                restoreCmd = ''${sname} dump "$snapshot" ${instance.request.backupName} | ${instance.request.restoreCmd}'';
+                listCmd = "exec ${sname} snapshots --json | ${pkgs.jq}/bin/jq -r '.[].id' ";
+                execCmd = "exec ${sname}";
               };
           in
           flatten (mapAttrsToList mkResticBinary cfg.databases);

--- a/modules/contracts/backup.nix
+++ b/modules/contracts/backup.nix
@@ -234,10 +234,10 @@ in
     {
       name,
       user,
-      sudoPreserveEnvs ? [ ],
-      secretsFile,
+      backupCmd,
       restoreCmd,
       listCmd,
+      execCmd,
     }:
     pkgs.writeShellApplication {
       inherit name;
@@ -245,40 +245,47 @@ in
       text = ''
         usage() {
           echo "$0 snapshots"
+          echo "$0 backup"
           echo "$0 restore <snapshot>"
+          echo "$0 exec <arg> [<args>...]"
         }
 
-        sudocmd() {
-          sudo --preserve-env=${lib.concatStringsSep "," sudoPreserveEnvs} -u ${user} "$@"
-        }
-
-        loadenv() {
-          set -a
-          # shellcheck disable=SC1090
-          source <(sudocmd cat "${secretsFile}")
-          set +a
-        }
-
-        if [ "$1" = "restore" ]; then
-          shift
-          snapshot="$1"
-
-          loadenv
-
-          echo "Will restore snapshot '$snapshot'"
-
-          sudocmd sh -c "${restoreCmd}"
-        elif [ "$1" = "snapshots" ]; then
-          shift
-
-          loadenv
-
-          sudocmd sh -c "${listCmd}"
-        else
+        if [ -z "''${1:-}" ]; then
           usage
-          exit 1
+          exit 0
         fi
+
+        set -x
+
+        case "$1" in
+          restore)
+            shift
+            snapshot="$1"
+
+            echo "Will restore snapshot '$snapshot'"
+
+            ${restoreCmd}
+            ;;
+          backup)
+            shift
+
+            ${backupCmd}
+            ;;
+          snapshots) 
+            shift
+
+            ${listCmd}
+            ;;
+          exec)
+            shift
+
+            ${execCmd}
+            ;;
+          *)
+            usage
+            exit 1
+            ;;
+        esac
       '';
     };
-
 }

--- a/modules/contracts/backup/test.nix
+++ b/modules/contracts/backup/test.nix
@@ -107,9 +107,12 @@ shb.test.runNixOSTest {
               })
 
       with subtest("Initial snapshot"):
-          out = machine.succeed("${provider.restoreScript} snapshots").splitlines()
-          if len(out) != 0:
-            raise Exception(f"Unexpected snapshots:\n{out}")
+          st, out = machine.execute("${provider.restoreScript} snapshots")
+          # We accept an error here
+          if st == 0:
+              out = out.splitlines()
+              if len(out) != 0:
+                  raise Exception(f"Unexpected snapshots:\n{out}")
 
       with subtest("First backup in repo"):
           print(machine.succeed("systemctl cat ${provider.backupService}"))

--- a/modules/contracts/databasebackup/test.nix
+++ b/modules/contracts/databasebackup/test.nix
@@ -84,10 +84,11 @@ shb.test.runNixOSTest {
           cmp_tables(res, table)
 
       with subtest("Initial snapshots"):
-          out = machine.succeed("${provider.restoreScript} snapshots").splitlines()
-          print(f"Found snapshots:\n{out}")
-          if len(out) != 0:
-              raise Exception(f"Unexpected snapshots:\n{out}")
+          st, out = machine.execute("${provider.restoreScript} snapshots")
+          if st == 0:
+              out = out.splitlines()
+              if len(out) != 0:
+                  raise Exception(f"Unexpected snapshots:\n{out}")
 
       with subtest("backup"):
           machine.succeed("systemctl start --wait ${provider.backupService}")


### PR DESCRIPTION
This makes it possible to run any command through the `exec` subcommand. Also, it reduces code maintenance.