### PR TITLE
update nixpkgs to 1b7a697fe6211e5ba1d989ec977eaae72fc3eed9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782683053,
-        "narHash": "sha256-lnE7l/t7toN3hjWb4R/u4O/jLh/GSPD/afAExmaqnbY=",
+        "lastModified": 1782650508,
+        "narHash": "sha256-yhGoxFv5MzSyJwE4sdyWuLSYFYBW7tFCymtaZ99LM/I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a0a3eb696eae60bc29a7316f5318c9110fd7ba3",
+        "rev": "1b7a697fe6211e5ba1d989ec977eaae72fc3eed9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1782683053,
+        "narHash": "sha256-lnE7l/t7toN3hjWb4R/u4O/jLh/GSPD/afAExmaqnbY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "3a0a3eb696eae60bc29a7316f5318c9110fd7ba3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
-        "owner": "nixos",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/9ae611a455b90cf061d8f332b977e387bda8e1ca...61b7c44c4073f0b827768aff0049561b5110ea5a ❌
 - https://github.com/NixOS/nixpkgs/compare/9ae611a455b90cf061d8f332b977e387bda8e1ca...3a0a3eb696eae60bc29a7316f5318c9110fd7ba3 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/bcfa15b87617d164753bfce48270705d54260f1c...1b7a697fe6211e5ba1d989ec977eaae72fc3eed9 (bisected in the past)