### PR TITLE
new block: show changed package versions on activation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -443,6 +443,7 @@
           self.nixosModules.mitmdump
           self.nixosModules.monitoring
           self.nixosModules.nginx
+          self.nixosModules.package-versions
           self.nixosModules.postgresql
           self.nixosModules.restic
           self.nixosModules.sanoid
@@ -483,6 +484,7 @@
       nixosModules.mitmdump = modules/blocks/mitmdump.nix;
       nixosModules.monitoring = modules/blocks/monitoring.nix;
       nixosModules.nginx = modules/blocks/nginx.nix;
+      nixosModules.package-versions = modules/blocks/package-versions.nix;
       nixosModules.postgresql = modules/blocks/postgresql.nix;
       nixosModules.restic = modules/blocks/restic.nix;
       nixosModules.sanoid = modules/blocks/sanoid.nix;

--- a/modules/blocks/package-versions.nix
+++ b/modules/blocks/package-versions.nix
@@ -1,0 +1,24 @@
+{ config, lib, ... }:
+{
+  options.package-versions = {
+    enable = lib.mkEnableOption "displaying the package versions that have changed when rebuilding the system";
+  };
+  config = {
+    system = {
+      activationScripts = {
+        diff-package-versions = lib.mkIf config.package-versions.enable {
+          supportsDryActivation = true;
+          text = ''
+            if [ -e /run/current-system ] && [ -e $systemConfig ]; then
+              echo
+              echo "updated package versions:"
+              echo
+              ${lib.getExe config.nix.package} --extra-experimental-features nix-command store diff-closures /run/current-system $systemConfig || true
+              echo
+            fi
+          '';
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Fixes #415

A group of us took a look at the "good first issue" tickets and picked this one to try tackling.

The NuschtOS version of this module also displays changes when the bootloader is installed, which we chose not to duplicate in the interests of keeping this PR simple. We also weren't certain whether we should put the new config option in some namespace; we saw that NuschtOS places this option within `config.nix`, which we thought seemed like a strange choice.

If you'd like any changes, please let us know!