### PR TITLE
nix flake update to bcfa15b87617d164753bfce48270705d54260f1c

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1782587597,
+        "narHash": "sha256-jHF18p08uMVh/OEdes8CWQQXk6XvAUITV8BTrTsp/MQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "bcfa15b87617d164753bfce48270705d54260f1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/bcfa15b87617d164753bfce48270705d54260f1c is the latest commit before Karakeep is broken by https://github.com/NixOS/nixpkgs/commit/3af24d1a5fc8a15e91c15da889ceefe21fc1b3b5.