### PR TITLE
deps: only use merge with rebase

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -36,15 +36,3 @@ jobs:
           review: ${{ github.event.inputs.review }}
           dry-run: false
 
-  automerge-merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: reitermarkus/automerge@v2
-        with:
-          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
-          merge-method: merge
-          do-not-merge-labels: never-merge
-          required-labels: automerge-merge
-          pull-request: ${{ github.event.inputs.pull-request }}
-          review: ${{ github.event.inputs.review }}
-          dry-run: false

--- a/.github/workflows/update-flake-lock-pr.nix
+++ b/.github/workflows/update-flake-lock-pr.nix
@@ -129,6 +129,7 @@ writeShellApplication {
       echo "Creating PR on nixpkgs' latest commit $test_commit"
 
       git checkout -B "$branch"
+      git reset --hard origin/main
 
       nix flake lock \
         --override-input nixpkgs "github:NixOS/nixpkgs/$test_commit"


### PR DESCRIPTION
There was a conflict between the two automerge jobs which made them always compete and actually never enable automerge.

Here we settle on always automerging with rebase and having the deps update job only create one commit.