### PR TITLE
Update nixpkgs and fix tests

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782587597,
-        "narHash": "sha256-jHF18p08uMVh/OEdes8CWQQXk6XvAUITV8BTrTsp/MQ=",
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bcfa15b87617d164753bfce48270705d54260f1c",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
             # Get rid of lldap patches when https://github.com/NixOS/nixpkgs/pull/425923 is merged.
             ./patches/lldap.patch
             ./patches/0001-nixos-borgbackup-add-option-to-override-state-direct.patch
+            ./patches/nixpkgs-deluge-upstream-fixes.patch
+            ./patches/nixpkgs-karakeep-pnpm11.patch
 
             # Leaving commented out as an example.
             # (originPkgs.fetchpatch {

--- a/patches/nixpkgs-deluge-upstream-fixes.patch
+++ b/patches/nixpkgs-deluge-upstream-fixes.patch
@@ -1,0 +1,25 @@
+--- a/pkgs/applications/networking/p2p/deluge/default.nix
++++ b/pkgs/applications/networking/p2p/deluge/default.nix
+@@ -2,0 +3 @@
++  fetchpatch,
+@@ -32,0 +34,14 @@
++      patches = [
++        (fetchpatch {
++          name = "deluge-remove-package-resources-dependency.patch";
++          url = "https://github.com/deluge-torrent/deluge/commit/18634913828900dedb836a81d96700cdadfb2b0a.patch";
++          excludes = [ "requirements.txt" ];
++          hash = "sha256-uqDoCumt6uljjlVY7K7qDuidD33oYO55cbNf3po0arY=";
++        })
++        (fetchpatch {
++          name = "deluge-replace-pyopenssl-certificate-generation.patch";
++          url = "https://github.com/deluge-torrent/deluge/commit/b763626ce88f9f9b82616de0a29087fde6d8828f.patch";
++          hash = "sha256-EtHcdZU1nCmLFrZiysoazRu9657NnuIbFdwRMhAWjI0=";
++        })
++      ];
++
+@@ -40,0 +56,3 @@
++          cryptography
++          pkginfo
++          platformdirs
+@@ -44 +61,0 @@
+-          setuptools

--- a/patches/nixpkgs-karakeep-pnpm11.patch
+++ b/patches/nixpkgs-karakeep-pnpm11.patch
@@ -1,0 +1,72 @@
+--- a/pkgs/by-name/ka/karakeep/package.nix
++++ b/pkgs/by-name/ka/karakeep/package.nix
+@@ -14 +14,2 @@
+-  pnpm_9,
++  util-linux,
++  pnpm,
+@@ -18,0 +20,29 @@
++let
++  # pnpm >= 10 intermittently fails to link nested esbuild copies during a
++  # parallel install (ERR_PNPM_ENOENT rename race). See:
++  # https://github.com/pnpm/pnpm/issues/10179
++  # The Karakeep pnpm 11 update follows unmerged work from this nixpkgs fork:
++  # https://github.com/three/nixpkgs/commit/ddd7f64e62beaed81fff7f534dd12236a5ec0434
++  # Constrain only `pnpm install`; keep the actual package build unconstrained.
++  pnpmForKarakeep = pnpm.overrideAttrs (oldAttrs: {
++    postFixup = (oldAttrs.postFixup or "") + ''
++      mv "$out/bin/pnpm" "$out/bin/.pnpm-unwrapped"
++      cat > "$out/bin/pnpm" <<EOF
++#!${stdenv.shell}
++if [ "\''${1-}" = install ]; then
++  cpuMask="\$(${lib.getExe' util-linux "taskset"} -cp "\$\$")"
++  # Keep only the cpuset reported after the colon.
++  cpuMask="\''${cpuMask##*: }"
++  # Pick the first comma-separated segment from the cpuset.
++  firstCpu="\''${cpuMask%%,*}"
++  # If that segment is a range, pick its first CPU.
++  firstCpu="\''${firstCpu%%-*}"
++  exec ${lib.getExe' util-linux "taskset"} -c "\$firstCpu" "$out/bin/.pnpm-unwrapped" "\$@"
++else
++  exec "$out/bin/.pnpm-unwrapped" "\$@"
++fi
++EOF
++      chmod +x "$out/bin/pnpm"
++    '';
++  });
++in
+@@ -26,2 +56,4 @@
+-    tag = "cli/v${finalAttrs.version}";
+-    hash = "sha256-P88DQi0T7tmBH7cjs8/Hz77bU0oG7u67XPoLsdePNhI=";
++    # Newer than current nixpkgs' cli/v0.32.0 tag, but still an unreleased
++    # Karakeep commit; the pnpm workaround follows https://github.com/three/nixpkgs/commit/ddd7f64e62beaed81fff7f534dd12236a5ec0434.
++    rev = "4af8bb2fd15beff338a791b7a8e0bbf9b72814d6";
++    hash = "sha256-H3SRXax+upFf9bHEg2Og9xuDlSnsnlokoWw1Bc89ZUQ=";
+@@ -32 +64,0 @@
+-    ./patches/dont-lock-pnpm-version.patch
+@@ -47 +78 @@
+-    pnpm_9
++    pnpmForKarakeep
+@@ -61,3 +92,3 @@
+-    pnpm = pnpm_9;
+-    fetcherVersion = 3;
+-    hash = "sha256-aT4JPx3iYw4kw8GHXKWMnelSVT0q2S3PK8DgSCQCyKQ=";
++    pnpm = pnpmForKarakeep;
++    fetcherVersion = 4;
++    hash = "sha256-/FTfQBuZrQljz5AiEKHLQoX0CJXmSNT0qXIG4K44Xvk=";
+--- a/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
++++ b/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
+@@ -5,10 +5,4 @@
+-@@ -495,7 +495,8 @@ class ImageOptimizerCache {
+-         ]);
+-     }
+-     constructor({ distDir, nextConfig }){
+--        this.cacheDir = (0, _path.join)(distDir, 'cache', 'images');
+-+        const cacheDir = process.env['NEXT_CACHE_DIR'] || (0, _path.join)(distDir, 'cache');
+-+        this.cacheDir = (0, _path.join)(cacheDir, 'images');
+-         this.nextConfig = nextConfig;
+-     }
+-     async get(cacheKey) {
++@@ -687 +687,2 @@ class ImageOptimizerCache {
++-        this.cacheDir = (0, _path.join)(/* turbopackIgnore: true */ distDir, 'cache', 'images');
+++        const cacheDir = process.env['NEXT_CACHE_DIR'] || (0, _path.join)(/* turbopackIgnore: true */ distDir, 'cache');
+++        this.cacheDir = (0, _path.join)(cacheDir, 'images');


### PR DESCRIPTION
Update flake inputs.

Deluge 2.2.0 still imports `pkg_resources`, which setuptools 82 no longer provides, and pyOpenSSL 26 removed X509Req. Patch nixpkgs centrally to keep Deluge on setuptools_80 and backport the certificate-generation fixes needed for current pyOpenSSL.

Karakeep needs pnpm 11-compatible packaging after the input update. Pin Karakeep to a source revision with pnpm 11 workspace metadata, update the existing Next cache patch to apply without changing semantics, and wrap pnpm so only pnpm install runs on one CPU to avoid the pnpm/esbuild rename race described in https://github.com/pnpm/pnpm/issues/10179.