### PR TITLE
Fix manual build across nixos-render-docs versions

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -203,6 +203,13 @@ stdenv.mkDerivation {
             "${ghRoot}" 2>/dev/null
       done
 
+    # Support both old and new nixos-render-docs option names.
+    if nixos-render-docs manual html --help | grep -q -- --sidebar-depth; then
+      sidebarDepthArgs="--sidebar-depth 1"
+    else
+      sidebarDepthArgs="--toc-depth 1 --section-toc-depth 1"
+    fi
+
     nixos-render-docs manual html \
       --manpage-urls ${manpage-urls} \
       --redirects ./redirects.json \
@@ -212,8 +219,7 @@ stdenv.mkDerivation {
       --stylesheet static/tomorrow-night.min.css \
       --script static/highlight.min.js \
       --script static/highlight.load.js \
-      --toc-depth 1 \
-      --section-toc-depth 1 \
+      $sidebarDepthArgs \
       manual.md \
       out/index.html
   '';


### PR DESCRIPTION
https://github.com/ibizaman/selfhostblocks/actions/runs/29735827497/job/88330792745?pr=757 failed because of:

```
nixos-render-docs manual html: error: --toc-depth has been removed, use --sidebar-depth instead
```

Replacing that one arg still raises:

```
nixos-render-docs manual html: error: --section-toc-depth has been removed, use --sidebar-depth instead
```

This PR replaces both args, but only if `--sidebar-depth` is documented in `nixos-render-docs manual html --help`. This way, it is compatible with nixpkgs both before and after https://github.com/ibizaman/selfhostblocks/pull/757.