### PR TITLE
Wait for PostgreSQL target in block tests

### DIFF
--- a/test/blocks/postgresql.nix
+++ b/test/blocks/postgresql.nix
@@ -32,7 +32,7 @@ in
       { nodes, ... }:
       ''
         start_all()
-        machine.wait_for_unit("postgresql.service")
+        machine.wait_for_unit("postgresql.target")
         machine.wait_for_open_port(5432)
 
         def peer_cmd(user, database):
@@ -80,7 +80,7 @@ in
       { nodes, ... }:
       ''
         start_all()
-        machine.wait_for_unit("postgresql.service")
+        machine.wait_for_unit("postgresql.target")
         machine.wait_for_open_port(5432)
 
         def peer_cmd(user, database):
@@ -128,7 +128,7 @@ in
       { nodes, ... }:
       ''
         start_all()
-        machine.wait_for_unit("postgresql.service")
+        machine.wait_for_unit("postgresql.target")
         machine.wait_for_open_port(5432)
 
         def peer_cmd(user, database):
@@ -185,7 +185,7 @@ in
         { nodes, ... }:
         ''
           start_all()
-          machine.wait_for_unit("postgresql.service")
+          machine.wait_for_unit("postgresql.target")
           machine.wait_for_open_port(5432)
 
           def peer_cmd(user, database):


### PR DESCRIPTION
Fix race:

* https://github.com/ibizaman/selfhostblocks/actions/runs/29735827497/job/88330966504?pr=757#step:5:2366 starts `subtest: can peer login with provisioned user and database`
* https://github.com/ibizaman/selfhostblocks/actions/runs/29735827497/job/88330966504?pr=757#step:5:2369 comes from PostgreSQL setup (`postgresql-setup-start[764]: CREATE DATABASE`)
* https://github.com/ibizaman/selfhostblocks/actions/runs/29735827497/job/88330966504?pr=757#step:5:2371 fails: `psql: error: connection to server on socket "/run/postgresql/.s.PGSQL.5432" failed: FATAL:  role "me-with-special-chars" does not exist`

so setup is still running while the test have already been launched.

Fix by adding an explicit dependency on `postgresql.target`.