### PR TITLE
update nixpkgs to 32a7d4135480472ccc9aa4d48dc0bb3775c5e6a4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1783527271,
+        "narHash": "sha256-Gmt3wNy8E1VU19ripHBAs+6hwuIZVjQA7uN5V+4hU/A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "32a7d4135480472ccc9aa4d48dc0bb3775c5e6a4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782587597,
-        "narHash": "sha256-jHF18p08uMVh/OEdes8CWQQXk6XvAUITV8BTrTsp/MQ=",
-        "owner": "nixos",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcfa15b87617d164753bfce48270705d54260f1c",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/bcfa15b87617d164753bfce48270705d54260f1c...241313f4e8e508cb9b13278c2b0fa25b9ca27163 ❌
 - https://github.com/NixOS/nixpkgs/compare/bcfa15b87617d164753bfce48270705d54260f1c...32a7d4135480472ccc9aa4d48dc0bb3775c5e6a4 (bisected in the past)