### PR TITLE
test: wait for client boot before access checks

### DIFF
--- a/test/common.nix
+++ b/test/common.nix
@@ -49,6 +49,7 @@ let
       import pathlib
 
       start_all()
+      client.wait_for_unit("multi-user.target")
 
       def curl(target, format, endpoint, data="", extra=""):
           cmd = ("curl --show-error --location"


### PR DESCRIPTION
After starting the VMs, the common access test waits for server services, ports, sockets, and URLs, but it does not wait for the client to finish booting before issuing client-side requests. This asymmetry may allow races with client initialization.

Wait for the client's multi-user.target before running readiness and access checks. This establishes client boot readiness without changing the existing application-specific server waits.