### PR TITLE
test: allow slow Nextcloud SSO consent redirects

### DIFF
--- a/test/services/nextcloud.nix
+++ b/test/services/nextcloud.nix
@@ -247,7 +247,8 @@ let
             username = "alice";
             password = "AlicePassword";
             nextPageExpect = [
-              "page.get_by_role('button', name=re.compile('Accept')).click()"
+              # Locator.click uses the action timeout while waiting for its navigation.
+              "page.get_by_role('button', name=re.compile('Accept')).click(timeout=2 * 60 * 1000)"
               "expect(page).to_have_title(re.compile('Dashboard'))"
               "page.goto('https://${config.test.fqdn}/settings/admin')"
               "expect(page.get_by_text('Access forbidden')).to_be_visible()"
@@ -264,7 +265,7 @@ let
             username = "bob";
             password = "BobPassword";
             nextPageExpect = [
-              "page.get_by_role('button', name=re.compile('Accept')).click()"
+              "page.get_by_role('button', name=re.compile('Accept')).click(timeout=2 * 60 * 1000)"
               "expect(page).to_have_title(re.compile('Dashboard'))"
               "page.goto('https://${config.test.fqdn}/settings/admin')"
               "expect(page.get_by_text('Access forbidden')).not_to_be_visible()"
@@ -288,7 +289,7 @@ let
             username = "charlie";
             password = "CharliePassword";
             nextPageExpect = [
-              "page.get_by_role('button', name=re.compile('Accept')).click()"
+              "page.get_by_role('button', name=re.compile('Accept')).click(timeout=2 * 60 * 1000)"
               "expect(page.get_by_text('not member of the allowed groups')).to_be_visible()"
             ];
           }


### PR DESCRIPTION
The Nextcloud SSO test timed out after 30 seconds while Locator.click waited for the redirect initiated by the consent button:

https://github.com/ibizaman/selfhostblocks/actions/runs/30083227948/job/89449477509

Locator.click uses the action timeout, so the helper's two-minute navigation timeout does not apply. Give every Nextcloud consent click the same two-minute allowance.