### PR TITLE
test: allow slow Nextcloud SSO error rendering

### DIFF
--- a/test/services/nextcloud.nix
+++ b/test/services/nextcloud.nix
@@ -290,7 +290,8 @@ let
             password = "CharliePassword";
             nextPageExpect = [
               "page.get_by_role('button', name=re.compile('Accept')).click(timeout=2 * 60 * 1000)"
-              "expect(page.get_by_text('not member of the allowed groups')).to_be_visible()"
+              # The Nextcloud error page can exceed Playwright's assertion timeout while rendering.
+              "expect(page.get_by_text('not member of the allowed groups')).to_be_visible(timeout=2 * 60 * 1000)"
             ];
           }
         ];


### PR DESCRIPTION
The denied-group response contained the expected message, but Nextcloud had not made it visible before Playwright's five-second assertion timeout:

https://github.com/ibizaman/selfhostblocks/actions/runs/30078978967/job/89436116874

Give this visibility assertion a two-minute allowance so it can wait for the Nextcloud error page to finish rendering.