### PR TITLE
update nixpkgs to 7aa20193ef7ad602223c86f3d3dfe7d05b2fce6d

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1784712339,
+        "narHash": "sha256-oGfT8NqWxl+kxi0lmQrVroyDS2ESi98dMqhhIckbdJM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "d6830397b3983f86b8ffe1c3bfb549b036eed476",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784558745,
-        "narHash": "sha256-+lHscESfk7nOscUGCSZKwfZRUQtShvKh0lOWOnFk+Wk=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3ea63d2f2590930cd14d7d769e5e0247e1c039e",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784712339,
-        "narHash": "sha256-oGfT8NqWxl+kxi0lmQrVroyDS2ESi98dMqhhIckbdJM=",
+        "lastModified": 1784666366,
+        "narHash": "sha256-avpO5HRRbfvrIxfSzcwPcxQ4wcjEj0fNlGetHV29OXk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6830397b3983f86b8ffe1c3bfb549b036eed476",
+        "rev": "7aa20193ef7ad602223c86f3d3dfe7d05b2fce6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/d3ea63d2f2590930cd14d7d769e5e0247e1c039e...e2587caef70cea85dd97d7daab492899902dbf5d ❌
 - https://github.com/NixOS/nixpkgs/compare/d3ea63d2f2590930cd14d7d769e5e0247e1c039e...d6830397b3983f86b8ffe1c3bfb549b036eed476 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/d3ea63d2f2590930cd14d7d769e5e0247e1c039e...7aa20193ef7ad602223c86f3d3dfe7d05b2fce6d (bisected in the past)