### PR TITLE
nextcloud: serialize setup and database maintenance

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -889,6 +889,9 @@ in
 
       systemd.services.nextcloud-setup.requires = cfg.mountPointServices;
       systemd.services.nextcloud-setup.after = cfg.mountPointServices;
+
+      # Ensure setup is in the same transaction when activation restarts this unit.
+      systemd.services.nextcloud-update-db.requires = [ "nextcloud-setup.service" ];
     })
 
     (lib.mkIf (cfg.enable && cfg.phpFpmPrometheusExporter.enable) {


### PR DESCRIPTION
https://github.com/ibizaman/selfhostblocks/actions/runs/30130071900/job/89602664669 started nextcloud-update-db.service and nextcloud-setup.service in separate systemd transactions during a version switch. That allowed db:add-missing-indices to race the Nextcloud upgrade and fail while an index disappeared concurrently.

Require nextcloud-setup.service from nextcloud-update-db.service so a direct activation start pulls setup into the same transaction and the existing After= ordering serializes them.