### PR TITLE
nextcloud: default to version 33

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -99,7 +99,7 @@ in
         32
         33
       ];
-      default = 32;
+      default = 33;
     };
 
     dataDir = lib.mkOption {


### PR DESCRIPTION
Make Nextcloud 33 the default now that the supported 32-to-33 migration path is covered by a VM test.