### PR TITLE
nextcloud: add version 34 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Template:
 
 # Upcoming Release
 
+## Breaking Changes
+
+- Nextcloud 33 and 34 are now supported, replacing versions 32 and 33. The default is now 33.
+  Deploy version 33 before selecting version 34 because Nextcloud does not support skipping major versions.
+
 ## User Facing Backwards Compatible Changes
 
 - Rename `shb.nginx.accessLog` to `shb.nginx.insecureAccessLogWithRequestBody`.

--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -23,6 +23,21 @@ let
   nextcloudApps =
     (builtins.getAttr ("nextcloud" + builtins.toString cfg.version + "Packages") pkgs).apps;
 
+  oidcLoginApp =
+    if cfg.version == 34 then
+      pkgs.nextcloud33Packages.apps.oidc_login.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [
+          # https://github.com/pulsejet/nextcloud-oidc-login/issues/335
+          # Upstream fix: https://github.com/pulsejet/nextcloud-oidc-login/pull/337
+          (pkgs.fetchpatch {
+            url = "https://github.com/pulsejet/nextcloud-oidc-login/commit/f8c6ae6053d36effed688195f551a1f1e6be24a0.patch";
+            hash = "sha256-KBx7Oh6xyNGyx6ryYTdWt6Y6zbpvzkp4bRAKwTcXjmg=";
+          })
+        ];
+      })
+    else
+      nextcloudApps.oidc_login;
+
   occ = "${config.services.nextcloud.occ}/bin/nextcloud-occ";
 in
 {
@@ -96,8 +111,8 @@ in
     version = lib.mkOption {
       description = "Nextcloud version to choose from.";
       type = lib.types.enum [
-        32
         33
+        34
       ];
       default = 33;
     };
@@ -1147,9 +1162,7 @@ in
           }
         ];
 
-        services.nextcloud.extraApps = {
-          inherit (nextcloudApps) oidc_login;
-        };
+        services.nextcloud.extraApps.oidc_login = oidcLoginApp;
 
         systemd.services.nextcloud-setup-pre = {
           wantedBy = [ "multi-user.target" ];

--- a/modules/services/nextcloud-server/docs/default.md
+++ b/modules/services/nextcloud-server/docs/default.md
@@ -125,8 +125,12 @@ To choose the version and upgrade at the time of your liking,
 just use the [version](#services-nextcloudserver-options-shb.nextcloud.version) option:
 
 ```nix
-shb.nextcloud.version = 29;
+shb.nextcloud.version = 34;
 ```
+
+Nextcloud only supports upgrading one major version at a time. When upgrading from
+an older version, select each supported major version in sequence and let the
+upgrade complete before selecting the next one.
 
 ### Mount Point {#services-nextcloudserver-usage-mount-point}
 

--- a/test/services/nextcloud.nix
+++ b/test/services/nextcloud.nix
@@ -1,8 +1,8 @@
 { lib, shb, ... }:
 let
   supportedVersion = [
-    32
     33
+    34
   ];
 
   adminUser = "root";
@@ -734,16 +734,16 @@ let
     };
 
   upgradeTest = shb.test.runNixOSTest {
-    name = "nextcloud_upgrade_32_33";
+    name = "nextcloud_upgrade_33_34";
 
     nodes.server = {
       imports = [
         basic
         {
-          shb.nextcloud.version = 32;
+          shb.nextcloud.version = 33;
 
-          specialisation.nextcloud33.configuration = {
-            shb.nextcloud.version = lib.mkForce 33;
+          specialisation.nextcloud34.configuration = {
+            shb.nextcloud.version = lib.mkForce 34;
           };
         }
       ];
@@ -754,9 +754,9 @@ let
     testScript =
       { nodes, ... }:
       let
-        nextcloud32Occ = "${nodes.server.services.nextcloud.occ}/bin/nextcloud-occ";
-        nextcloud33Occ = "${nodes.server.specialisation.nextcloud33.configuration.services.nextcloud.occ}/bin/nextcloud-occ";
-        switch = "${nodes.server.system.build.toplevel}/specialisation/nextcloud33/bin/switch-to-configuration test";
+        nextcloud33Occ = "${nodes.server.services.nextcloud.occ}/bin/nextcloud-occ";
+        nextcloud34Occ = "${nodes.server.specialisation.nextcloud34.configuration.services.nextcloud.occ}/bin/nextcloud-occ";
+        switch = "${nodes.server.system.build.toplevel}/specialisation/nextcloud34/bin/switch-to-configuration test";
         webdavUrl = "http://${nodes.server.test.fqdn}/remote.php/dav/files/${adminUser}/upgrade-marker";
         curl =
           "curl --fail --silent --show-error --user ${adminUser}:${adminPass}"
@@ -769,22 +769,22 @@ let
         server.wait_for_unit("multi-user.target")
         server.wait_for_unit("phpfpm-nextcloud.service")
 
-        with subtest("Nextcloud 32 is ready"):
-            status = json.loads(server.succeed("${nextcloud32Occ} status --output=json"))
+        with subtest("Nextcloud 33 is ready"):
+            status = json.loads(server.succeed("${nextcloud33Occ} status --output=json"))
             assert status["installed"]
-            assert status["versionstring"].startswith("32.")
+            assert status["versionstring"].startswith("33.")
             assert not status["maintenance"]
 
         with subtest("create data before the upgrade"):
             server.succeed("printf 'survives upgrade' > /tmp/upgrade-marker")
             server.succeed("${curl} --upload-file /tmp/upgrade-marker ${webdavUrl}")
 
-        with subtest("upgrade to Nextcloud 33"):
+        with subtest("upgrade to Nextcloud 34"):
             server.succeed("${switch}")
             server.wait_for_unit("phpfpm-nextcloud.service")
-            status = json.loads(server.succeed("${nextcloud33Occ} status --output=json"))
+            status = json.loads(server.succeed("${nextcloud34Occ} status --output=json"))
             assert status["installed"]
-            assert status["versionstring"].startswith("33.")
+            assert status["versionstring"].startswith("34.")
             assert not status["maintenance"]
 
         with subtest("data survives the upgrade"):
@@ -814,12 +814,12 @@ let
 
       "prometheus_${toString v}" = prometheusTest v;
     }
-    // lib.optionalAttrs (v == 32) {
+    // lib.optionalAttrs (v == 34) {
       "memories_${toString v}" = memoriesTest v;
       "recognize_${toString v}" = recognizeTest v;
     };
 in
 (lib.foldl (all: v: lib.mergeAttrs all (versionedTests v)) { } supportedVersion)
 // {
-  upgrade_32_33 = upgradeTest;
+  upgrade_33_34 = upgradeTest;
 }


### PR DESCRIPTION
Replace supported Nextcloud versions 32/33 with 33/34, update the versioned tests, and move upgrade coverage from 32-to-33 to 33-to-34.

Nextcloud does not support skipping major versions. Existing version 32 installations must upgrade to 33 before deploying 34.

The packaged oidc_login app does not yet declare Nextcloud 34 compatibility. Temporarily reuse the Nextcloud 33 app package and apply the upstream fix from https://github.com/pulsejet/nextcloud-oidc-login/pull/337.