### PR TITLE
flake: update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784558745,
-        "narHash": "sha256-+lHscESfk7nOscUGCSZKwfZRUQtShvKh0lOWOnFk+Wk=",
-        "owner": "NixOS",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3ea63d2f2590930cd14d7d769e5e0247e1c039e",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
             ./patches/0001-nixos-borgbackup-add-option-to-override-state-direct.patch
             ./patches/nixpkgs-deluge-upstream-fixes.patch
             ./patches/nixpkgs-karakeep-pnpm11.patch
+            ./patches/nixpkgs-mitmproxy-drop-unused-msgpack.patch
 
             # Leaving commented out as an example.
             # (originPkgs.fetchpatch {

--- a/patches/nixpkgs-mitmproxy-drop-unused-msgpack.patch
+++ b/patches/nixpkgs-mitmproxy-drop-unused-msgpack.patch
@@ -1,0 +1,30 @@
+diff --git a/pkgs/development/python-modules/mitmproxy/default.nix b/pkgs/development/python-modules/mitmproxy/default.nix
+--- a/pkgs/development/python-modules/mitmproxy/default.nix
++++ b/pkgs/development/python-modules/mitmproxy/default.nix
+@@ -17,7 +17,6 @@
+   kaitaistruct,
+   ldap3,
+   mitmproxy-rs,
+-  msgpack,
+   nixosTests,
+   publicsuffix2,
+   pyopenssl,
+@@ -65,6 +64,10 @@ buildPythonPackage rec {
+     "wsproto"
+   ];
+ 
++  # msgpack is unused and was removed upstream:
++  # https://github.com/mitmproxy/mitmproxy/pull/8319
++  pythonRemoveDeps = [ "msgpack" ];
++
+   build-system = [ setuptools ];
+ 
+   dependencies = [
+@@ -82,7 +85,6 @@ buildPythonPackage rec {
+     kaitaistruct
+     ldap3
+     mitmproxy-rs
+-    msgpack
+     publicsuffix2
+     pyopenssl
+     pyparsing


### PR DESCRIPTION
Update nixpkgs to `e2587caef70cea85dd97d7daab492899902dbf5d`.

The same revision failed in https://github.com/ibizaman/selfhostblocks/actions/runs/30130122228 (triggered from https://github.com/ibizaman/selfhostblocks/pull/772) with:

```
Checking runtime dependencies for mitmproxy-12.2.3-py3-none-any.whl
  - msgpack<=1.1.2,>=1.0.0 not satisfied by version 1.2.1
```

Mitmproxy no longer uses msgpack. Backport its upstream removal through `patchedNixpkgs` so the Python runtime dependency check succeeds.