### PR TITLE
test: wait for Grafana SSO redirect

### DIFF
--- a/test/blocks/monitoring.nix
+++ b/test/blocks/monitoring.nix
@@ -104,6 +104,7 @@ let
               "page.get_by_role('button', name=re.compile('Accept')).click()"
               "expect(page.get_by_text(re.compile('[Ii]ncorrect'))).not_to_be_visible(timeout=10000)"
               "expect(page.get_by_role('button', name=re.compile('Sign In'))).not_to_be_visible()"
+              "expect(page).to_have_url(re.compile('^https://${config.test.fqdn}/'), timeout=20000)"
               ''
                 assert page.evaluate("""
                     async () => {
@@ -133,6 +134,7 @@ let
               "page.get_by_role('button', name=re.compile('Accept')).click()"
               "expect(page.get_by_text(re.compile('[Ii]ncorrect'))).not_to_be_visible(timeout=10000)"
               "expect(page.get_by_role('button', name=re.compile('Sign In'))).not_to_be_visible()"
+              "expect(page).to_have_url(re.compile('^https://${config.test.fqdn}/'), timeout=20000)"
               ''
                 assert page.evaluate("""
                     async () => {


### PR DESCRIPTION
https://github.com/ibizaman/selfhostblocks/actions/runs/30206684674 failed vm_monitoring_sso because the test queried Grafana's relative /api/user endpoint while the browser was still on Authelia's authorization page.

Wait for the Grafana URL after accepting consent before checking the authenticated user.