### PR TITLE
nginx: clarify insecure request body logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Template:
 
 # Upcoming Release
 
+## User Facing Backwards Compatible Changes
+
+- Rename `shb.nginx.accessLog` to `shb.nginx.insecureAccessLogWithRequestBody`.
+  The old option remains available as a deprecated alias.
+
 # v0.9.0
 
 Commits: https://github.com/ibizaman/selfhostblocks/compare/v0.8.0...v0.9.0

--- a/demo/nextcloud/flake.nix
+++ b/demo/nextcloud/flake.nix
@@ -51,7 +51,7 @@
           shb.sops.secret."nextcloud/adminpass".request = config.shb.nextcloud.adminPass.request;
 
           # Set to true for more debug info with `journalctl -f -u nginx`.
-          shb.nginx.accessLog = true;
+          shb.nginx.insecureAccessLogWithRequestBody = true;
           shb.nginx.debugLog = false;
         };
 

--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -1247,11 +1247,12 @@
   "blocks-nginx-options": [
     "blocks-nginx.html#blocks-nginx-options"
   ],
-  "blocks-nginx-options-shb.nginx.accessLog": [
-    "blocks-nginx.html#blocks-nginx-options-shb.nginx.accessLog"
-  ],
   "blocks-nginx-options-shb.nginx.debugLog": [
     "blocks-nginx.html#blocks-nginx-options-shb.nginx.debugLog"
+  ],
+  "blocks-nginx-options-shb.nginx.insecureAccessLogWithRequestBody": [
+    "blocks-nginx.html#blocks-nginx-options-shb.nginx.insecureAccessLogWithRequestBody",
+    "blocks-nginx.html#blocks-nginx-options-shb.nginx.accessLog"
   ],
   "blocks-nginx-options-shb.nginx.vhosts": [
     "blocks-nginx.html#blocks-nginx-options-shb.nginx.vhosts"

--- a/modules/blocks/nginx.nix
+++ b/modules/blocks/nginx.nix
@@ -95,13 +95,17 @@ let
 in
 {
   imports = [
+    (lib.mkRenamedOptionModule
+      [ "shb" "nginx" "accessLog" ]
+      [ "shb" "nginx" "insecureAccessLogWithRequestBody" ]
+    )
     ./authelia.nix
   ];
 
   options.shb.nginx = {
-    accessLog = lib.mkOption {
+    insecureAccessLogWithRequestBody = lib.mkOption {
       type = lib.types.bool;
-      description = "Log all requests";
+      description = "Log all requests, including potentially sensitive request bodies";
       default = false;
       example = true;
     };
@@ -128,7 +132,7 @@ in
 
     services.nginx.enable = true;
     services.nginx.logError = lib.mkIf cfg.debugLog "stderr warn";
-    services.nginx.appendHttpConfig = lib.mkIf cfg.accessLog ''
+    services.nginx.appendHttpConfig = lib.mkIf cfg.insecureAccessLogWithRequestBody ''
       log_format apm
         '{'
         '"remote_addr":"$remote_addr",'

--- a/modules/blocks/nginx/docs/default.md
+++ b/modules/blocks/nginx/docs/default.md
@@ -8,13 +8,15 @@ It complements the upstream nixpkgs with some authentication and debugging impro
 
 ## Usage {#blocks-nginx-usage}
 
-### Access Logging {#blocks-nginx-usage-accesslog}
+### Access Logging with Request Bodies {#blocks-nginx-usage-accesslog}
 
-JSON access logging is enabled with the [`shb.nginx.accessLog`](#blocks-nginx-options-shb.nginx.accessLog) option:
+JSON access logging, including potentially sensitive request bodies, is enabled
+with the [`shb.nginx.insecureAccessLogWithRequestBody`](#blocks-nginx-options-shb.nginx.insecureAccessLogWithRequestBody)
+option:
 
 ```nix
 {
-  shb.nginx.accessLog = true;
+  shb.nginx.insecureAccessLogWithRequestBody = true;
 }
 ```
 
@@ -45,7 +47,9 @@ nginx[969]: server nginx:
   }
 ```
 
-This _will_ log the body of POST queries so it should only be enabled for debug logging.
+This logs request bodies and can expose passwords, authentication tokens, and
+other private data in the system journal. It should only be enabled temporarily
+for debugging.
 
 ### Debug Logging {#blocks-nginx-usage-debuglog}
 

--- a/test/common.nix
+++ b/test/common.nix
@@ -250,7 +250,7 @@ in
           80
           443
         ];
-        shb.nginx.accessLog = true;
+        shb.nginx.insecureAccessLogWithRequestBody = true;
 
         networking.hosts = {
           "192.168.1.2" = [


### PR DESCRIPTION
Rename shb.nginx.accessLog to shb.nginx.insecureAccessLogWithRequestBody so configurations make the credential exposure explicit. Keep the old option as a deprecated alias and preserve its documentation redirect.