### PR TITLE
test: run mitmdump VM headlessly

### DIFF
--- a/test/blocks/mitmdump.nix
+++ b/test/blocks/mitmdump.nix
@@ -57,6 +57,7 @@ in
       { config, pkgs, ... }:
       {
         imports = [
+          shb.test.baseImports
           ../../modules/blocks/mitmdump.nix
         ];
 


### PR DESCRIPTION
https://github.com/ibizaman/selfhostblocks/actions/runs/30211794366/job/89819273519?pr=776

Linux 6.18.39 hit a kernel BUG while loading graphical QEMU console modules, leaving systemd unreachable even though both mitmdump instances had started. Import the shared headless/QEMU guest test profile so this network-only test avoids that unrelated graphics path.