### PR TITLE
test: avoid waiting on restarting Jellyfin unit

### DIFF
--- a/test/services/jellyfin.nix
+++ b/test/services/jellyfin.nix
@@ -35,7 +35,7 @@ let
     waitForServices =
       { ... }:
       [
-        "jellyfin.service"
+        "multi-user.target"
         "nginx.service"
       ];
     waitForPorts =


### PR DESCRIPTION
Jellyfin deliberately restarts itself after SHB writes its initial configuration. The generic unit wait can observe that transition as a failure even though the service later becomes ready.

Rely on the existing port, HTTP, API-authentication, and browser checks, which verify the post-restart application state.