### PR TITLE
monitoring: bind Scrutiny web UI to loopback

### DIFF
--- a/modules/blocks/monitoring.nix
+++ b/modules/blocks/monitoring.nix
@@ -936,7 +936,7 @@ in
         settings = {
           web = {
             metrics.enabled = true; # Enables Prometheus exporter
-            listenHost = "127.0.0.1";
+            listen.host = "127.0.0.1";
           };
         };
 


### PR DESCRIPTION
Scrutiny's free-form settings expect web.listen.host. The previous listenHost key was ignored, leaving the application on its broad default bind address.

Use the supported nested key so Scrutiny honors the intended loopback-only configuration.