### PR TITLE
monitoring: add dedicated Scrutiny SSL option

### DIFF
--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -1079,6 +1079,21 @@
   "blocks-monitoring-options-shb.monitoring.scrutiny.enable": [
     "blocks-monitoring.html#blocks-monitoring-options-shb.monitoring.scrutiny.enable"
   ],
+  "blocks-monitoring-options-shb.monitoring.scrutiny.ssl": [
+    "blocks-monitoring.html#blocks-monitoring-options-shb.monitoring.scrutiny.ssl"
+  ],
+  "blocks-monitoring-options-shb.monitoring.scrutiny.ssl.paths": [
+    "blocks-monitoring.html#blocks-monitoring-options-shb.monitoring.scrutiny.ssl.paths"
+  ],
+  "blocks-monitoring-options-shb.monitoring.scrutiny.ssl.paths.cert": [
+    "blocks-monitoring.html#blocks-monitoring-options-shb.monitoring.scrutiny.ssl.paths.cert"
+  ],
+  "blocks-monitoring-options-shb.monitoring.scrutiny.ssl.paths.key": [
+    "blocks-monitoring.html#blocks-monitoring-options-shb.monitoring.scrutiny.ssl.paths.key"
+  ],
+  "blocks-monitoring-options-shb.monitoring.scrutiny.ssl.systemdService": [
+    "blocks-monitoring.html#blocks-monitoring-options-shb.monitoring.scrutiny.ssl.systemdService"
+  ],
   "blocks-monitoring-options-shb.monitoring.scrutiny.subdomain": [
     "blocks-monitoring.html#blocks-monitoring-options-shb.monitoring.scrutiny.subdomain"
   ],

--- a/modules/blocks/monitoring.nix
+++ b/modules/blocks/monitoring.nix
@@ -123,6 +123,12 @@ in
         '';
         default = "scrutiny";
       };
+      ssl = lib.mkOption {
+        description = "SSL certificate for the Scrutiny web interface. Defaults to `shb.monitoring.ssl` for backwards compatibility.";
+        type = lib.types.nullOr shb.contracts.ssl.certs;
+        default = cfg.ssl;
+        defaultText = lib.literalExpression "config.shb.monitoring.ssl";
+      };
       dashboard = lib.mkOption {
         description = ''
           Dashboard contract consumer
@@ -965,8 +971,8 @@ in
       shb.nginx.vhosts = lib.mkIf (cfg.scrutiny.subdomain != null) [
         (
           {
-            inherit (cfg) domain ssl;
-            subdomain = cfg.scrutiny.subdomain;
+            inherit (cfg) domain;
+            inherit (cfg.scrutiny) ssl subdomain;
 
             upstream = "http://127.0.0.1:${toString config.services.scrutiny.settings.web.listen.port}";
             autheliaRules = lib.optionals (cfg.sso.enable) [

--- a/test/blocks/monitoring.nix
+++ b/test/blocks/monitoring.nix
@@ -188,6 +188,39 @@ let
       };
     };
 
+  scrutinySsl =
+    { config, ... }:
+    {
+      shb.certs.certs.selfsigned = {
+        monitoring = {
+          ca = config.shb.certs.cas.selfsigned.myca;
+          domain = "g.${config.test.domain}";
+          group = "nginx";
+        };
+        scrutiny = {
+          ca = config.shb.certs.cas.selfsigned.myca;
+          domain = "scrutiny.${config.test.domain}";
+          group = "nginx";
+        };
+      };
+
+      shb.monitoring = {
+        ssl = config.shb.certs.certs.selfsigned.monitoring;
+        scrutiny.ssl = config.shb.certs.certs.selfsigned.scrutiny;
+      };
+
+      systemd.services.nginx = {
+        after = [
+          config.shb.certs.certs.selfsigned.monitoring.systemdService
+          config.shb.certs.certs.selfsigned.scrutiny.systemdService
+        ];
+        requires = [
+          config.shb.certs.certs.selfsigned.monitoring.systemdService
+          config.shb.certs.certs.selfsigned.scrutiny.systemdService
+        ];
+      };
+    };
+
   clientScrutinyLoginSso =
     { config, ... }:
     {
@@ -372,7 +405,7 @@ in
           basic
           scrutiny
           shb.test.certs
-          https
+          scrutinySsl
           shb.test.ldap
           ldap
           (shb.test.sso config.shb.certs.certs.selfsigned.n)
@@ -382,6 +415,20 @@ in
         # virtualisation.memorySize = 4096;
       };
 
-    testScript = commonTestScript;
+    testScript = commonTestScript.override {
+      extraScript =
+        { node, ... }:
+        let
+          scrutinyFqdn = "${node.config.shb.monitoring.scrutiny.subdomain}.${node.config.shb.monitoring.domain}";
+        in
+        ''
+          with subtest("Scrutiny uses its own SSL certificate"):
+              client.succeed(
+                  "curl --fail --silent --show-error"
+                  + " --connect-to ${scrutinyFqdn}:443:server:443"
+                  + " https://${scrutinyFqdn}/"
+              )
+        '';
+    };
   };
 }


### PR DESCRIPTION
The Scrutiny vhost always reused shb.monitoring.ssl, requiring one certificate to cover both Grafana and Scrutiny.

Add shb.monitoring.scrutiny.ssl, default it to the monitoring-wide certificate for compatibility, and wire the Scrutiny vhost to it. Exercise the option with non-overlapping certificates so hostname verification fails if the parent certificate is used.