### PR TITLE
mailserver: update nixos-mailserver to 26.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Template:
 - Remove the ignored `shb.zfs.pools.<pool>.datasets.<dataset>.enable` option.
   Remove the option from existing configurations and conditionally omit the dataset attribute instead.
 
+- Update NixOS Mailserver to the 26.11 development branch. The
+  `shb.mailserver.impermanence.sieve` output is removed because user-managed
+  Sieve scripts now live under `mailserver.storage.path`. Users with
+  `mailserver.enableManageSieve = true` must complete the
+  [upstream Sieve migration](https://nixos-mailserver.readthedocs.io/en/nixos-26.05/migrations.html#sieve-script-directory-migration)
+  before setting `shb.mailserver.stateVersion = 5`.
+
 ## User Facing Backwards Compatible Changes
 
 - Rename `shb.nginx.accessLog` to `shb.nginx.insecureAccessLogWithRequestBody`.

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     "nixos-mailserver": {
       "flake": false,
       "locked": {
-        "lastModified": 1777287493,
-        "narHash": "sha256-Fj7S91TuZm6+DG/v6SFme/p+sWrYMQICGX6yQ5KD43Q=",
+        "lastModified": 1785242276,
+        "narHash": "sha256-sJI/6nAkckPii1HUCNj4XwPV6E7CZ9t75WX/XQvSyG8=",
         "owner": "simple-nixos-mailserver",
         "repo": "nixos-mailserver",
-        "rev": "e33fbde199eaad513ef5d0746db19d5878150232",
+        "rev": "d4165c1dc93aa7bb3019e5a90960c121e228cad5",
         "type": "gitlab"
       },
       "original": {

--- a/modules/services/mailserver.nix
+++ b/modules/services/mailserver.nix
@@ -345,7 +345,7 @@ in
 
     backup = lib.mkOption {
       description = ''
-        Backup emails, index and sieve.
+        Backup emails, index and Sieve scripts.
       '';
       default = { };
       type = lib.types.submodule {
@@ -354,13 +354,11 @@ in
           sourceDirectories = builtins.filter (x: x != null) [
             config.mailserver.indexDir
             config.mailserver.storage.path
-            config.mailserver.sieveDirectory
           ];
           sourceDirectoriesText = ''
             [
               config.mailserver.indexDir
               config.mailserver.storage.path
-              config.mailserver.sieveDirectory
             ]
           '';
         };
@@ -395,7 +393,6 @@ in
       type = lib.types.attrsOf lib.types.str;
       default = {
         mail = config.mailserver.storage.path;
-        sieve = config.mailserver.sieveDirectory;
         dkim = config.mailserver.dkim.keyDirectory;
       }
       // lib.optionalAttrs (config.mailserver.indexDir != null) {
@@ -404,7 +401,6 @@ in
       defaultText = lib.literalExpression ''
         {
           mail = config.mailserver.storage.path;
-          sieve = config.mailserver.sieveDirectory;
           dkim = config.mailserver.dkim.keyDirectory;
         }
         // lib.optionalAttrs (config.mailserver.indexDir != null) {
@@ -599,13 +595,6 @@ in
         "userdb ldap" = {
           fields.home = lib.mkForce "${config.mailserver.storage.path}/${cfg.ldap.account}/%{user}";
           fields.mail_index_path = lib.mkForce "${config.mailserver.storage.path}/${cfg.ldap.account}/%{user}";
-        };
-        "passdb ldap" = {
-          # LLDAP does not understand ldap user password setup.
-          fields.password = lib.mkForce null;
-          # We use bind DN auth.
-          # https://doc.dovecot.org/2.3/configuration_manual/authentication/ldap_bind/#authentication-ldap-bind
-          bind = true;
         };
       };
     })

--- a/modules/services/mailserver/docs/default.md
+++ b/modules/services/mailserver/docs/default.md
@@ -236,7 +236,6 @@ To save the data folder in an impermanence setup, add:
 ```nix
 {
   shb.zfs.datasets."safe/mailserver/mail".path = config.shb.mailserver.impermanence.mail;
-  shb.zfs.datasets."safe/mailserver/sieve".path = config.shb.mailserver.impermanence.sieve;
   shb.zfs.datasets."safe/mailserver/dkim".path = config.shb.mailserver.impermanence.dkim;
 }
 ```
@@ -292,12 +291,11 @@ The 3 systemd services setup by this module are:
 
 ### Folders {#services-mailserver-debug-folders}
 
-The folders where state is stored are:
+The persistent locations used by the module are:
 
 - `config.mailserver.indexDir`, when configured, stores disposable search indices.
-- `config.mailserver.storage.path` = `/var/vmail`
-- `config.mailserver.sieveDirectory` = `/var/sieve`
-- `config.mailserver.dkim.keyDirectory` = `/var/dkim`
+- `config.mailserver.storage.path` = `/var/vmail` stores mail and user-managed Sieve scripts.
+- `config.mailserver.dkim.keyDirectory` = `/var/dkim` stores DKIM keys.
 
 ### Open Ports {#services-mailserver-debug-ports}
 
@@ -309,7 +307,7 @@ The ports opened by default in this module are:
 You will need to forward those ports on your router
 if you want to access to your emails from the internet.
 
-The complete list can be found in the [upstream repository](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/5965fae920b6b97f39f94bdb6195631e274c93a5/mail-server/networking.nix).
+The complete list can be found in the [upstream repository](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/d4165c1dc93aa7bb3019e5a90960c121e228cad5/mail-server/networking.nix).
 
 ### List Email Provider Folder Mapping {#services-mailserver-debug-folder-mapping}
 


### PR DESCRIPTION
Update the pinned upstream module to the current development branch and adapt SHB to its storage and LDAP interfaces. Sieve state now lives in storage.path; use the structured DKIM key option and upstream LDAP bind-auth support.

Keep stateVersion at 4 so ManageSieve users must perform the upstream migration before opting into 5.