### PR TITLE
mailserver: fetch upstream module as a flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,6 +33,23 @@
         "type": "github"
       }
     },
+    "nixos-mailserver": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777287493,
+        "narHash": "sha256-Fj7S91TuZm6+DG/v6SFme/p+sWrYMQICGX6yQ5KD43Q=",
+        "owner": "simple-nixos-mailserver",
+        "repo": "nixos-mailserver",
+        "rev": "e33fbde199eaad513ef5d0746db19d5878150232",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "simple-nixos-mailserver",
+        "ref": "main",
+        "repo": "nixos-mailserver",
+        "type": "gitlab"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1784796856,
@@ -69,6 +86,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nix-flake-tests": "nix-flake-tests",
+        "nixos-mailserver": "nixos-mailserver",
         "nixpkgs": "nixpkgs",
         "nmdsrc": "nmdsrc"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixos-mailserver = {
+      url = "gitlab:simple-nixos-mailserver/nixos-mailserver/main";
+      flake = false;
+    };
     nix-flake-tests.url = "github:antifuchs/nix-flake-tests";
     flake-utils.url = "github:numtide/flake-utils";
     nmdsrc = {
@@ -15,6 +19,7 @@
     inputs@{
       self,
       nixpkgs,
+      nixos-mailserver,
       nix-flake-tests,
       flake-utils,
       nmdsrc,
@@ -133,7 +138,9 @@
             "services/homepage" = ./modules/services/homepage.nix;
             "services/jellyfin" = ./modules/services/jellyfin.nix;
             "services/karakeep" = ./modules/services/karakeep.nix;
-            "services/mailserver" = ./modules/services/mailserver.nix;
+            "services/mailserver" = {
+              module = self.nixosModules.mailserver;
+            };
             "services/nextcloud-server" = {
               module = ./modules/services/nextcloud-server.nix;
               optionRoot = [
@@ -368,6 +375,7 @@
                 removeAttrs
                   (pkgs.callPackage path {
                     shb = self.lib.${system};
+                    inherit (self) nixosModules;
                   })
                   [
                     "override"
@@ -509,7 +517,13 @@
       nixosModules.homepage = modules/services/homepage.nix;
       nixosModules.jellyfin = modules/services/jellyfin.nix;
       nixosModules.karakeep = modules/services/karakeep.nix;
-      nixosModules.mailserver = modules/services/mailserver.nix;
+      # Unlike the other modules, mailserver composes an external flake input with the SHB module.
+      nixosModules.mailserver = {
+        imports = [
+          (nixos-mailserver + "/default.nix")
+          modules/services/mailserver.nix
+        ];
+      };
       nixosModules.nextcloud-server = modules/services/nextcloud-server.nix;
       nixosModules.open-webui = modules/services/open-webui.nix;
       nixosModules.paperless = modules/services/paperless.nix;

--- a/modules/services/mailserver.nix
+++ b/modules/services/mailserver.nix
@@ -9,17 +9,7 @@ let
   cfg = config.shb.mailserver;
 in
 {
-  imports = [
-    (
-      builtins.fetchGit {
-        url = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver.git";
-        ref = "master";
-        rev = "e33fbde199eaad513ef5d0746db19d5878150232";
-      }
-      + "/default.nix"
-    )
-    ../blocks/lldap.nix
-  ];
+  imports = [ ../blocks/lldap.nix ];
 
   options.shb.mailserver = {
     enable = lib.mkEnableOption "SHB's nixos-mailserver module";

--- a/test/services/immich.nix
+++ b/test/services/immich.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   shb,
+  ...
 }:
 let
   subdomain = "i";

--- a/test/services/mailserver.nix
+++ b/test/services/mailserver.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  nixosModules,
   pkgs,
   shb,
   ...
@@ -80,7 +81,7 @@ in
       {
         imports = [
           ../../modules/blocks/ssl.nix
-          ../../modules/services/mailserver.nix
+          nixosModules.mailserver
         ];
 
         networking.hosts = {

--- a/test/services/paperless.nix
+++ b/test/services/paperless.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   shb,
+  ...
 }:
 let
   subdomain = "p";


### PR DESCRIPTION
Track the nixos-mailserver source in flake.lock instead of fetching it during module evaluation. Keep the public mailserver module self-contained by composing the locked upstream source with the SHB module, and exercise that public wrapper in tests and documentation.