### PR TITLE
nextcloud: default to version 34

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -114,7 +114,7 @@ in
         33
         34
       ];
-      default = 33;
+      default = 34;
     };
 
     dataDir = lib.mkOption {


### PR DESCRIPTION
Make Nextcloud 34 the default now that support and the 33-to-34 migration path are covered by VM tests.