### PR TITLE
Standardize option naming: use config.mailserver.dkim.keyDirectory

### DIFF
--- a/modules/services/mailserver.nix
+++ b/modules/services/mailserver.nix
@@ -381,7 +381,7 @@ in
           ];
           sourceDirectoriesText = ''
             [
-              config.mailserver.dkimKeyDirectory
+              config.mailserver.dkim.keyDirectory
             ]
           '';
         };
@@ -396,7 +396,7 @@ in
       default = {
         mail = config.mailserver.storage.path;
         sieve = config.mailserver.sieveDirectory;
-        dkim = config.mailserver.dkimKeyDirectory;
+        dkim = config.mailserver.dkim.keyDirectory;
       }
       // lib.optionalAttrs (config.mailserver.indexDir != null) {
         index = config.mailserver.indexDir;
@@ -405,7 +405,7 @@ in
         {
           mail = config.mailserver.storage.path;
           sieve = config.mailserver.sieveDirectory;
-          dkim = config.mailserver.dkimKeyDirectory;
+          dkim = config.mailserver.dkim.keyDirectory;
         }
         // lib.optionalAttrs (config.mailserver.indexDir != null) {
           index = config.mailserver.indexDir;

--- a/modules/services/mailserver/docs/default.md
+++ b/modules/services/mailserver/docs/default.md
@@ -297,7 +297,7 @@ The folders where state is stored are:
 - `config.mailserver.indexDir`, when configured, stores disposable search indices.
 - `config.mailserver.mailDirectory` = `/var/vmail`
 - `config.mailserver.sieveDirectory` = `/var/sieve`
-- `config.mailserver.dkimKeyDirectory` = `/var/dkim`
+- `config.mailserver.dkim.keyDirectory` = `/var/dkim`
 
 ### Open Ports {#services-mailserver-debug-ports}
 


### PR DESCRIPTION
This is the default option; `dkimKeyDirectory` is a rename: https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/blob/531aa78a9f03f3831aa45566630ab52f6483159b/default.nix#L1517