### PR TITLE
mailserver: handle optional index directory

### DIFF
--- a/modules/services/mailserver.nix
+++ b/modules/services/mailserver.nix
@@ -394,17 +394,21 @@ in
       '';
       type = lib.types.attrsOf lib.types.str;
       default = {
-        index = config.mailserver.indexDir;
         mail = config.mailserver.storage.path;
         sieve = config.mailserver.sieveDirectory;
         dkim = config.mailserver.dkimKeyDirectory;
+      }
+      // lib.optionalAttrs (config.mailserver.indexDir != null) {
+        index = config.mailserver.indexDir;
       };
       defaultText = lib.literalExpression ''
         {
-          index = config.mailserver.indexDir;
           mail = config.mailserver.storage.path;
           sieve = config.mailserver.sieveDirectory;
           dkim = config.mailserver.dkimKeyDirectory;
+        }
+        // lib.optionalAttrs (config.mailserver.indexDir != null) {
+          index = config.mailserver.indexDir;
         }
       '';
     };

--- a/modules/services/mailserver/docs/default.md
+++ b/modules/services/mailserver/docs/default.md
@@ -235,11 +235,18 @@ To save the data folder in an impermanence setup, add:
 
 ```nix
 {
-  shb.zfs.datasets."safe/mailserver/index".path = config.shb.mailserver.impermanence.index;
   shb.zfs.datasets."safe/mailserver/mail".path = config.shb.mailserver.impermanence.mail;
   shb.zfs.datasets."safe/mailserver/sieve".path = config.shb.mailserver.impermanence.sieve;
   shb.zfs.datasets."safe/mailserver/dkim".path = config.shb.mailserver.impermanence.dkim;
 }
+```
+
+By default, search indices live under `mailserver.storage.path` and are covered
+by the mail dataset. If you configure a separate `mailserver.indexDir` and want
+to persist it, also add:
+
+```nix
+shb.zfs.datasets."safe/mailserver/index".path = config.shb.mailserver.impermanence.index;
 ```
 
 ### Declarative LDAP {#services-mailserver-declarative-ldap}
@@ -285,9 +292,9 @@ The 3 systemd services setup by this module are:
 
 ### Folders {#services-mailserver-debug-folders}
 
-The 4 folders where state is stored are:
+The folders where state is stored are:
 
-- `config.mailserver.indexDir` = `/var/lib/dovecot/indices`
+- `config.mailserver.indexDir`, when configured, stores disposable search indices.
 - `config.mailserver.mailDirectory` = `/var/vmail`
 - `config.mailserver.sieveDirectory` = `/var/sieve`
 - `config.mailserver.dkimKeyDirectory` = `/var/dkim`


### PR DESCRIPTION
nixos-mailserver defaults mailserver.indexDir to null and stores indices alongside mail. Omit the impermanence index output unless a separate path is configured, and document both layouts.