### PR TITLE
update nixpkgs to 63e9d4af17d57fc1ea780a713c1f5fea222c03bc

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785015559,
-        "narHash": "sha256-ztKLAb87iH6dmIPdaoI21eJr8Blc+lzRMJ7XdI8aY2M=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91f1117bdd1c9ee1cb07733146db7c93c71dd3ac",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785397190,
-        "narHash": "sha256-bVKdaxejPO1W4mzD4RyBG9t7xy9tID09jXSWBaFdIvo=",
+        "lastModified": 1785196106,
+        "narHash": "sha256-tqFWkHKrNaGVBfLBreoR5aRYub4W8rnztGKCYO+VFj0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adde2f2f410aa4b5ed6a3eba7201a4f8b19f9045",
+        "rev": "63e9d4af17d57fc1ea780a713c1f5fea222c03bc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "lastModified": 1785397190,
+        "narHash": "sha256-bVKdaxejPO1W4mzD4RyBG9t7xy9tID09jXSWBaFdIvo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "adde2f2f410aa4b5ed6a3eba7201a4f8b19f9045",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/91f1117bdd1c9ee1cb07733146db7c93c71dd3ac...e72e4f299401a3689d4b3d5fc6496b11db7064eb ❌
 - https://github.com/NixOS/nixpkgs/compare/91f1117bdd1c9ee1cb07733146db7c93c71dd3ac...adde2f2f410aa4b5ed6a3eba7201a4f8b19f9045 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/91f1117bdd1c9ee1cb07733146db7c93c71dd3ac...63e9d4af17d57fc1ea780a713c1f5fea222c03bc (bisected in the past)