### PR TITLE
nextcloud: update Preview Generator settings

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -324,16 +324,17 @@ in
                 recommendedSettings = lib.mkOption {
                   type = lib.types.bool;
                   description = ''
-                    Better defaults than the defaults. Taken from [this article](http://web.archive.org/web/20200513043150/https://ownyourbits.com/2019/06/29/understanding-and-improving-nextcloud-previews/).
+                    Configure the minimal preview set recommended by [Preview Generator](https://github.com/nextcloud/previewgenerator/blob/edcd988b963e034a0ea7d5a1c6a72744b822f7c8/README.md#i-dont-want-to-generate-all-the-preview-sizes).
 
                     Sets the following options:
 
                     ```
-                    nextcloud-occ config:app:set previewgenerator squareSizes --value="32 256"
-                    nextcloud-occ config:app:set previewgenerator widthSizes  --value="256 384"
-                    nextcloud-occ config:app:set previewgenerator heightSizes --value="256"
-                    nextcloud-occ config:system:set preview_max_x --type integer --value 2048
-                    nextcloud-occ config:system:set preview_max_y --type integer --value 2048
+                    nextcloud-occ config:app:set previewgenerator squareSizes --value="64 256"
+                    nextcloud-occ config:app:set previewgenerator fillWidthHeightSizes --value="256 4096"
+                    nextcloud-occ config:app:set previewgenerator widthSizes --value=""
+                    nextcloud-occ config:app:set previewgenerator heightSizes --value=""
+                    nextcloud-occ config:system:set preview_max_x --type integer --value 4096
+                    nextcloud-occ config:system:set preview_max_y --type integer --value 4096
                     nextcloud-occ config:system:set jpeg_quality --value 60
                     nextcloud-occ config:app:set preview jpeg_quality --value=60
                     ```
@@ -1011,14 +1012,15 @@ in
 
       };
 
-      # Values taken from
-      # http://web.archive.org/web/20200513043150/https://ownyourbits.com/2019/06/29/understanding-and-improving-nextcloud-previews/
+      # Minimal preview set recommended by
+      # https://github.com/nextcloud/previewgenerator/blob/edcd988b963e034a0ea7d5a1c6a72744b822f7c8/README.md#i-dont-want-to-generate-all-the-preview-sizes
       systemd.services.nextcloud-setup.script = lib.mkIf cfg.apps.previewgenerator.recommendedSettings ''
-        ${occ} config:app:set previewgenerator squareSizes --value="32 256"
-        ${occ} config:app:set previewgenerator widthSizes  --value="256 384"
-        ${occ} config:app:set previewgenerator heightSizes --value="256"
-        ${occ} config:system:set preview_max_x --type integer --value 2048
-        ${occ} config:system:set preview_max_y --type integer --value 2048
+        ${occ} config:app:set previewgenerator squareSizes --value="64 256"
+        ${occ} config:app:set previewgenerator fillWidthHeightSizes --value="256 4096"
+        ${occ} config:app:set previewgenerator widthSizes --value=""
+        ${occ} config:app:set previewgenerator heightSizes --value=""
+        ${occ} config:system:set preview_max_x --type integer --value 4096
+        ${occ} config:system:set preview_max_y --type integer --value 4096
         ${occ} config:system:set jpeg_quality --value 60
         ${occ} config:app:set preview jpeg_quality --value=60
       '';

--- a/modules/services/nextcloud-server/docs/default.md
+++ b/modules/services/nextcloud-server/docs/default.md
@@ -381,9 +381,10 @@ Note that you still need to generate the previews for any pre-existing files wit
 nextcloud-occ -vvv preview:generate-all
 ```
 
-The default settings generates all possible sizes which is a waste since most are not used. SHB will
-change the generation settings to optimize disk space and CPU usage as outlined in [this
-article](http://web.archive.org/web/20200513043150/https://ownyourbits.com/2019/06/29/understanding-and-improving-nextcloud-previews/).
+The default settings generate all possible sizes, even though most are not used. SHB configures the
+[minimal preview set recommended by Preview
+Generator](https://github.com/nextcloud/previewgenerator/blob/edcd988b963e034a0ea7d5a1c6a72744b822f7c8/README.md#i-dont-want-to-generate-all-the-preview-sizes)
+to reduce disk and CPU usage.
 You can opt-out with:
 
 ```nix


### PR DESCRIPTION
Preview Generator 5.14 ignores the old 32 and 384 sizes because supported sizes start at 64 and must be powers of four:

https://github.com/nextcloud/previewgenerator/blob/edcd988b963e034a0ea7d5a1c6a72744b822f7c8/README.md#available-configuration-options

Upstream documents 64/256 squares plus 256/4096 filled previews as its minimal set:

https://github.com/nextcloud/previewgenerator/blob/edcd988b963e034a0ea7d5a1c6a72744b822f7c8/README.md#i-dont-want-to-generate-all-the-preview-sizes

Raise the managed preview bounds to 4096 so upgraded installations do not discard the new 4096 size. Keep the existing JPEG quality settings and update the module documentation to reference the current upstream recommendation.