### PR TITLE
zfs: remove ignored dataset enable option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Template:
 
 - Nextcloud 33 and 34 are now supported, replacing versions 32 and 33. The default is now 33.
   Deploy version 33 before selecting version 34 because Nextcloud does not support skipping major versions.
+- Remove the ignored `shb.zfs.pools.<pool>.datasets.<dataset>.enable` option.
+  Remove the option from existing configurations and conditionally omit the dataset attribute instead.
 
 ## User Facing Backwards Compatible Changes
 

--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -1872,7 +1872,8 @@
     "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools"
   ],
   "blocks-zfs-options-shb.zfs.pools._name_.datasets": [
-    "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools._name_.datasets"
+    "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools._name_.datasets",
+    "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.enable"
   ],
   "blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.after": [
     "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.after"
@@ -1930,9 +1931,6 @@
   ],
   "blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.defaultACLs": [
     "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.defaultACLs"
-  ],
-  "blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.enable": [
-    "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.enable"
   ],
   "blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.group": [
     "blocks-zfs.html#blocks-zfs-options-shb.zfs.pools._name_.datasets._name_.group"

--- a/modules/blocks/zfs.nix
+++ b/modules/blocks/zfs.nix
@@ -53,8 +53,6 @@ in
                   { config, name, ... }:
                   {
                     options = {
-                      enable = lib.mkEnableOption "shb.zfs.datasets";
-
                       path = lib.mkOption {
                         type = lib.types.str;
                         description = "Path this dataset should be mounted on. If the string 'none' is given, the dataset will not be mounted.";


### PR DESCRIPTION
The per-dataset enable option has never affected service generation, so setting it to false still creates and mounts the dataset.

Remove the misleading option and redirect its documentation anchor to the parent dataset options. Configurations that need conditional datasets must omit the dataset attribute instead.