### PR TITLE
open-webui: back up DynamicUser state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Template:
 - Rename `shb.nginx.accessLog` to `shb.nginx.insecureAccessLogWithRequestBody`.
   The old option remains available as a deprecated alias.
 
+## Fixes
+
+- Fix Open WebUI backups omitting state stored in systemd's private DynamicUser directory
+  ([issue #721](https://github.com/ibizaman/selfhostblocks/issues/721)).
+
 # v0.9.0
 
 Commits: https://github.com/ibizaman/selfhostblocks/compare/v0.8.0...v0.9.0

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -152,11 +152,12 @@ in
       default = { };
       type = lib.types.submodule {
         options = shb.contracts.backup.mkRequester {
-          user = "open-webui";
+          # Restic does not follow the compatibility symlink created for DynamicUser state.
+          # See https://github.com/ibizaman/selfhostblocks/issues/721.
+          user = "root";
           sourceDirectories = [
-            config.services.open-webui.stateDir
+            "/var/lib/private/open-webui"
           ];
-          sourceDirectoriesText = "[ config.services.open-webui.stateDir ]";
         };
       };
     };

--- a/test/services/open-webui.nix
+++ b/test/services/open-webui.nix
@@ -202,7 +202,42 @@ in
 
     nodes.client = { };
 
-    testScript = commonTestScript.backup;
+    testScript = commonTestScript.backup.override {
+      extraScript =
+        { node, ... }:
+        let
+          provider = node.config.shb.restic.instances."testinstance";
+          restoreScript = provider.result.restoreScript;
+        in
+        ''
+          state_directory = pathlib.Path("/var/lib/private/open-webui")
+          database = state_directory / "data" / "webui.db"
+          sentinel = state_directory / "backup-sentinel"
+          restore_target = pathlib.Path("/tmp/open-webui-restore")
+
+          with subtest("Prepare state for backup"):
+              server.succeed(f"test -s {database}")
+              server.succeed(
+                  f"printf '%s\\n' 'included in backup' > {sentinel}"
+              )
+
+          with subtest("Back up and restore state"):
+              server.succeed("${restoreScript} backup")
+              server.succeed(
+                  f"${restoreScript} exec restore latest --target {restore_target}"
+              )
+
+          with subtest("Restored backup contains application state"):
+              restored_state = restore_target / state_directory.relative_to("/")
+              restored_database = restored_state / "data" / "webui.db"
+              restored_sentinel = restored_state / "backup-sentinel"
+              server.succeed(f"test -s {restored_database}")
+              server.succeed(
+                  f"grep --fixed-strings --line-regexp 'included in backup' "
+                  f"{restored_sentinel}"
+              )
+        '';
+    };
   };
 
   https = shb.test.runNixOSTest {


### PR DESCRIPTION
Restic archives symlinks without following them, so the previous /var/lib/open-webui source omitted the application state under /var/lib/private/open-webui.

Run the backup as root against the physical state directory. Extend the existing backup VM test to restore a snapshot and verify that application state is present.

Fixes https://github.com/ibizaman/selfhostblocks/issues/721.