### PR TITLE
test: use current Nextcloud admin option

### DIFF
--- a/test/services/nextcloud.nix
+++ b/test/services/nextcloud.nix
@@ -136,7 +136,7 @@ let
         # This option is only needed because we do not access Nextcloud at the default port in the VM.
         externalFqdn = "${config.test.fqdn}:8080";
 
-        adminUser = adminUser;
+        initialAdminUsername = adminUser;
         adminPass.result = config.shb.hardcodedsecret.adminPass.result;
         debug = false; # Enable this if needed, but beware it is _very_ verbose.
       };


### PR DESCRIPTION
Configure initialAdminUsername directly instead of relying on the deprecated adminUser alias, avoiding an evaluation warning in every Nextcloud VM test.