### PR TITLE
nextcloud: run preview generation as service user

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -1038,6 +1038,7 @@ in
       systemd.services.nextcloud-cron-previewgenerator = {
         environment.NEXTCLOUD_CONFIG_DIR = "${config.services.nextcloud.datadir}/config";
         serviceConfig.Type = "oneshot";
+        serviceConfig.User = "nextcloud";
         serviceConfig.ExecStart =
           let
             debug = if cfg.debug or cfg.apps.previewgenerator.debug then "-vvv" else "";

--- a/test/services/nextcloud.nix
+++ b/test/services/nextcloud.nix
@@ -574,7 +574,13 @@ let
 
       nodes.client = { };
 
-      testScript = commonTestScript.access;
+      testScript =
+        inputs@{ nodes, ... }:
+        (commonTestScript.access inputs)
+        + ''
+          with subtest("preview generator job succeeds"):
+              server.succeed("systemctl start nextcloud-cron-previewgenerator.service")
+        '';
     };
 
   externalStorageTest =


### PR DESCRIPTION
Run the preview-generator maintenance job as nextcloud instead of root. Exercise the oneshot in both versioned preview-generator VM tests to verify it retains the required access.