### PR TITLE
nextcloud: pass credentials to preview generation

### DIFF
--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -1030,6 +1030,7 @@ in
         environment.NEXTCLOUD_CONFIG_DIR = "${config.services.nextcloud.datadir}/config";
         serviceConfig.Type = "oneshot";
         serviceConfig.User = "nextcloud";
+        serviceConfig.LoadCredential = config.systemd.services.nextcloud-cron.serviceConfig.LoadCredential;
         serviceConfig.ExecStart =
           let
             debug = if cfg.debug or cfg.apps.previewgenerator.debug then "-vvv" else "";

--- a/test/services/nextcloud.nix
+++ b/test/services/nextcloud.nix
@@ -377,7 +377,9 @@ let
     {
       systemd.tmpfiles.rules = [
         "d '/srv/nextcloud' 0750 nextcloud nextcloud - -"
+        "f /run/nextcloud-instanceid 0400 nextcloud nextcloud - oc12345abcde"
       ];
+      services.nextcloud.secrets.instanceid = "/run/nextcloud-instanceid";
 
       shb.nextcloud = {
         apps.previewgenerator.enable = true;


### PR DESCRIPTION
https://github.com/ibizaman/selfhostblocks/pull/806 changed the preview-generator oneshot to run as nextcloud but did not give it the runtime credentials required by the generated nextcloud-occ wrapper. With services.nextcloud.secrets configured, the wrapper falls back to systemd-run.

Without this fix, the regression test fails to start nextcloud-cron-previewgenerator.service with: systemd-run: Failed to start transient service unit: Access denied

Reuse the core Nextcloud cron service credential list and exercise the credential path on both supported Nextcloud versions. Ordinary Nextcloud tests retain coverage of the no-runtime-secret wrapper path.