### PR TITLE
update nixpkgs to 2bf0e25ac62426473c58ab049e7bde5ce20e17d2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
-        "owner": "nixos",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785967620,
-        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
+        "lastModified": 1785887929,
+        "narHash": "sha256-izf2B3FVTzw+CJabRgbiUd/Xxv/fAd174cvPRgOJNoI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
+        "rev": "2bf0e25ac62426473c58ab049e7bde5ce20e17d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/e72e4f299401a3689d4b3d5fc6496b11db7064eb...b7c2ada94fe99c15b0dbcf4d11fd7850b957a436 ❌
 - https://github.com/NixOS/nixpkgs/compare/e72e4f299401a3689d4b3d5fc6496b11db7064eb...2bf0e25ac62426473c58ab049e7bde5ce20e17d2 (bisected in the past)