### PR TITLE
Migrate systemd.tmpfiles.rules to systemd.tmpfiles.settings

### DIFF
--- a/modules/blocks/restic.nix
+++ b/modules/blocks/restic.nix
@@ -278,9 +278,9 @@ in
                 group = "root";
               };
             };
-            instances = filterAttrs (
-              name: instance: hasPrefix "/" instance.settings.repository.path
-            ) (cfg.instances // cfg.databases);
+            instances = filterAttrs (name: instance: hasPrefix "/" instance.settings.repository.path) (
+              cfg.instances // cfg.databases
+            );
           in
           listToAttrs (
             mapAttrsToList (

--- a/modules/blocks/restic.nix
+++ b/modules/blocks/restic.nix
@@ -269,15 +269,24 @@ in
       }
       {
         # Create repository if it is a local path.
-        systemd.tmpfiles.rules =
+        systemd.tmpfiles.settings."10-shb-restic" =
           let
-            mkSettings =
-              name: instance:
-              optionals (hasPrefix "/" instance.settings.repository.path) [
-                "d '${instance.settings.repository.path}' 0750 ${instance.request.user} root - -"
-              ];
+            mkSettings = name: instance: {
+              d = {
+                mode = "0750";
+                user = instance.request.user;
+                group = "root";
+              };
+            };
+            instances = filterAttrs (
+              name: instance: hasPrefix "/" instance.settings.repository.path
+            ) (cfg.instances // cfg.databases);
           in
-          flatten (mapAttrsToList mkSettings (cfg.instances // cfg.databases));
+          listToAttrs (
+            mapAttrsToList (
+              name: instance: nameValuePair instance.settings.repository.path (mkSettings name instance)
+            ) instances
+          );
       }
       {
         services.restic.backups =

--- a/modules/blocks/vpn.nix
+++ b/modules/blocks/vpn.nix
@@ -292,8 +292,17 @@ in
       in
       lib.mkMerge (lib.mapAttrsToList instanceConfig cfg);
 
-    systemd.tmpfiles.rules = map (name: "d /tmp/openvpn/${name}.status 0700 root root") (
-      lib.attrNames cfg
+    systemd.tmpfiles.settings."10-shb-vpn" = lib.listToAttrs (
+      map (
+        name:
+        lib.nameValuePair "/tmp/openvpn/${name}.status" {
+          d = {
+            mode = "0700";
+            user = "root";
+            group = "root";
+          };
+        }
+      ) (lib.attrNames cfg)
     );
 
     networking.iproute2.enable = true;

--- a/modules/services/arr.nix
+++ b/modules/services/arr.nix
@@ -460,9 +460,13 @@ in
         isSSOEnabled = !(isNull cfg'.authEndpoint);
       in
       {
-        systemd.tmpfiles.rules = [
-          "d ${cfg'.dataDir} 0700 ${config.services.sonarr.user} ${config.services.sonarr.user}"
-        ];
+        systemd.tmpfiles.settings."10-shb-arr" = {
+          "${cfg'.dataDir}".d = {
+            mode = "0700";
+            user = config.services.sonarr.user;
+            group = config.services.sonarr.user;
+          };
+        };
 
         services.nginx.enable = true;
 

--- a/modules/services/deluge.nix
+++ b/modules/services/deluge.nix
@@ -406,16 +406,18 @@ in
           )
         );
 
-        systemd.tmpfiles.rules =
+        systemd.tmpfiles.settings."10-shb-deluge" =
           let
             plugins = pkgs.symlinkJoin {
               name = "deluge-plugins";
               paths = cfg.additionalPlugins;
             };
           in
-          [
-            "L+ ${cfg.dataDir}/.config/deluge/plugins - - - - ${plugins}"
-          ];
+          {
+            "${cfg.dataDir}/.config/deluge/plugins"."L+" = {
+              argument = "${plugins}";
+            };
+          };
 
         shb.nginx.vhosts = [
           (

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -408,11 +408,27 @@ in
         generator = shb.replaceSecretsGeneratorAdapter (lib.generators.toYAML { });
       });
 
-    systemd.tmpfiles.rules = [
-      "f ${config.services.home-assistant.configDir}/automations.yaml 0755 hass hass"
-      "f ${config.services.home-assistant.configDir}/scenes.yaml      0755 hass hass"
-      "f ${config.services.home-assistant.configDir}/scripts.yaml     0755 hass hass"
-      "d /var/lib/hass/backups 0750 hass hass"
-    ];
+    systemd.tmpfiles.settings."10-shb-home-assistant" = {
+      "${config.services.home-assistant.configDir}/automations.yaml".f = {
+        mode = "0755";
+        user = "hass";
+        group = "hass";
+      };
+      "${config.services.home-assistant.configDir}/scenes.yaml".f = {
+        mode = "0755";
+        user = "hass";
+        group = "hass";
+      };
+      "${config.services.home-assistant.configDir}/scripts.yaml".f = {
+        mode = "0755";
+        user = "hass";
+        group = "hass";
+      };
+      "/var/lib/hass/backups".d = {
+        mode = "0750";
+        user = "hass";
+        group = "hass";
+      };
+    };
   };
 }

--- a/modules/services/immich.nix
+++ b/modules/services/immich.nix
@@ -533,9 +533,13 @@ in
     };
 
     # Create basic directories for Immich
-    systemd.tmpfiles.rules = [
-      "d /var/lib/immich 0700 immich immich"
-    ];
+    systemd.tmpfiles.settings."10-shb-immich" = {
+      "/var/lib/immich".d = {
+        mode = "0700";
+        user = "immich";
+        group = "immich";
+      };
+    };
 
     # Configuration setup service - generates config only for SHB-managed settings
     systemd.services.immich-setup-config =

--- a/modules/services/jellyfin.nix
+++ b/modules/services/jellyfin.nix
@@ -738,9 +738,13 @@ in
       lib.optionals cfg.ldap.enable [ cfg.ldap.plugin ]
       ++ lib.optionals cfg.sso.enable [ cfg.sso.plugin ];
 
-    systemd.tmpfiles.rules = lib.optionals cfg.ldap.enable [
-      "d '${config.services.jellyfin.dataDir}/plugins' 0750 jellyfin jellyfin - -"
-    ];
+    systemd.tmpfiles.settings."10-shb-jellyfin" = lib.optionalAttrs cfg.ldap.enable {
+      "${config.services.jellyfin.dataDir}/plugins".d = {
+        mode = "0750";
+        user = "jellyfin";
+        group = "jellyfin";
+      };
+    };
 
     systemd.services.jellyfin.serviceConfig.ExecStartPost =
       let

--- a/modules/services/mailserver.nix
+++ b/modules/services/mailserver.nix
@@ -602,29 +602,27 @@ in
       systemd.tmpfiles.settings."10-shb-mailserver" =
         let
           # The equal sign makes sure parent directories have the corret user and group too.
-          mkAccount =
-            name: acct:
-            [
-              (lib.nameValuePair "${config.mailserver.storage.path}/${name}" {
-                d = {
-                  mode = "0750";
-                  user = config.mailserver.storage.owner;
-                  group = config.mailserver.storage.group;
-                };
-              })
-              (lib.nameValuePair "${config.mailserver.storage.path}/${name}/${acct.username}" {
-                d = {
-                  mode = "0750";
-                  user = config.mailserver.storage.owner;
-                  group = config.mailserver.storage.group;
-                };
-              })
-              (lib.nameValuePair "${config.mailserver.storage.path}/${name}/${acct.username}/mail/" {
-                d = {
-                  user = "virtualMail";
-                };
-              })
-            ];
+          mkAccount = name: acct: [
+            (lib.nameValuePair "${config.mailserver.storage.path}/${name}" {
+              d = {
+                mode = "0750";
+                user = config.mailserver.storage.owner;
+                group = config.mailserver.storage.group;
+              };
+            })
+            (lib.nameValuePair "${config.mailserver.storage.path}/${name}/${acct.username}" {
+              d = {
+                mode = "0750";
+                user = config.mailserver.storage.owner;
+                group = config.mailserver.storage.group;
+              };
+            })
+            (lib.nameValuePair "${config.mailserver.storage.path}/${name}/${acct.username}/mail/" {
+              d = {
+                user = "virtualMail";
+              };
+            })
+          ];
         in
         lib.listToAttrs (lib.flatten (lib.mapAttrsToList mkAccount cfg.imapSync.accounts));
 

--- a/modules/services/mailserver.nix
+++ b/modules/services/mailserver.nix
@@ -601,15 +601,32 @@ in
     (lib.mkIf (cfg.enable && cfg.imapSync != null) {
       systemd.tmpfiles.settings."10-shb-mailserver" =
         let
-          mkSettings =
+          # The equal sign makes sure parent directories have the corret user and group too.
+          mkAccount =
             name: acct:
-            lib.nameValuePair "${config.mailserver.storage.path}/${name}/${acct.username}/mail/" {
-              d = {
-                user = "virtualMail";
-              };
-            };
+            [
+              (lib.nameValuePair "${config.mailserver.storage.path}/${name}" {
+                d = {
+                  mode = "0750";
+                  user = config.mailserver.storage.owner;
+                  group = config.mailserver.storage.group;
+                };
+              })
+              (lib.nameValuePair "${config.mailserver.storage.path}/${name}/${acct.username}" {
+                d = {
+                  mode = "0750";
+                  user = config.mailserver.storage.owner;
+                  group = config.mailserver.storage.group;
+                };
+              })
+              (lib.nameValuePair "${config.mailserver.storage.path}/${name}/${acct.username}/mail/" {
+                d = {
+                  user = "virtualMail";
+                };
+              })
+            ];
         in
-        lib.mapAttrs' mkSettings cfg.imapSync.accounts;
+        lib.listToAttrs (lib.flatten (lib.mapAttrsToList mkAccount cfg.imapSync.accounts));
 
       systemd.services.mbsync =
         let
@@ -712,18 +729,6 @@ in
               ${pkgs.isync}/bin/mbsync --all ${debug} --config ${configFile}
             '';
         };
-
-      systemd.tmpfiles.rules =
-        let
-          mkAccount =
-            name: acct:
-            # The equal sign makes sure parent directories have the corret user and group too.
-            [
-              "d '${config.mailserver.storage.path}/${name}' 0750 ${config.mailserver.storage.owner} ${config.mailserver.storage.group} - -"
-              "d '${config.mailserver.storage.path}/${name}/${acct.username}' 0750 ${config.mailserver.storage.owner} ${config.mailserver.storage.group} - -"
-            ];
-        in
-        lib.flatten (lib.mapAttrsToList mkAccount cfg.imapSync.accounts);
 
       systemd.timers.mbsync = {
         wantedBy = [ "timers.target" ];

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -280,9 +280,13 @@ in
         ];
 
         systemd.services.open-webui.serviceConfig.EnvironmentFile = "/run/open-webui/secrets.env";
-        systemd.tmpfiles.rules = [
-          "d '/run/open-webui' 0750 root root - -"
-        ];
+        systemd.tmpfiles.settings."10-shb-open-webui" = {
+          "/run/open-webui".d = {
+            mode = "0750";
+            user = "root";
+            group = "root";
+          };
+        };
         systemd.services.open-webui-pre = {
           script = shb.replaceSecrets {
             userConfig = {

--- a/modules/services/paperless.nix
+++ b/modules/services/paperless.nix
@@ -399,12 +399,30 @@ in
 
     # Database defaults to local sqlite
 
-    systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir} 0700 paperless paperless"
-      "d ${cfg.consumptionDir} 0700 paperless paperless"
-      "d ${cfg.mediaDir} 0700 paperless paperless"
-    ]
-    ++ lib.optionals cfg.sso.enable [ "d '/run/paperless' 0750 root root - -" ];
+    systemd.tmpfiles.settings."10-shb-paperless" = {
+      "${cfg.dataDir}".d = {
+        mode = "0700";
+        user = "paperless";
+        group = "paperless";
+      };
+      "${cfg.consumptionDir}".d = {
+        mode = "0700";
+        user = "paperless";
+        group = "paperless";
+      };
+      "${cfg.mediaDir}".d = {
+        mode = "0700";
+        user = "paperless";
+        group = "paperless";
+      };
+    }
+    // lib.optionalAttrs cfg.sso.enable {
+      "/run/paperless".d = {
+        mode = "0750";
+        user = "root";
+        group = "root";
+      };
+    };
 
     systemd.services.paperless-pre = lib.mkIf cfg.sso.enable {
       script = replaceSecretsScript;

--- a/modules/services/pinchflat.nix
+++ b/modules/services/pinchflat.nix
@@ -148,9 +148,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '/run/pinchflat' 0750 root root - -"
-    ];
+    systemd.tmpfiles.settings."10-shb-pinchflat" = {
+      "/run/pinchflat".d = {
+        mode = "0750";
+        user = "root";
+        group = "root";
+      };
+    };
 
     # Pinchflat relies on the global value so for now this is the only way to pass the option in.
     time.timeZone = lib.mkDefault cfg.timeZone;

--- a/modules/services/vaultwarden.nix
+++ b/modules/services/vaultwarden.nix
@@ -217,10 +217,18 @@ in
     };
     # We create a blank environment file for the service to start. Then, ExecPreStart kicks in and
     # fills out the environment file for ExecStart to pick it up.
-    systemd.tmpfiles.rules = [
-      "d ${dataFolder} 0750 vaultwarden vaultwarden"
-      "f ${dataFolder}/vaultwarden.env 0640 vaultwarden vaultwarden"
-    ];
+    systemd.tmpfiles.settings."10-shb-vaultwarden" = {
+      "${dataFolder}".d = {
+        mode = "0750";
+        user = "vaultwarden";
+        group = "vaultwarden";
+      };
+      "${dataFolder}/vaultwarden.env".f = {
+        mode = "0640";
+        user = "vaultwarden";
+        group = "vaultwarden";
+      };
+    };
     # Needed to be able to write template config.
     systemd.services.vaultwarden.serviceConfig.ProtectHome = lib.mkForce false;
     systemd.services.vaultwarden.preStart = shb.replaceSecrets {

--- a/test/services/nextcloud.nix
+++ b/test/services/nextcloud.nix
@@ -375,10 +375,19 @@ let
   previewgenerator =
     { config, ... }:
     {
-      systemd.tmpfiles.rules = [
-        "d '/srv/nextcloud' 0750 nextcloud nextcloud - -"
-        "f /run/nextcloud-instanceid 0400 nextcloud nextcloud - oc12345abcde"
-      ];
+      systemd.tmpfiles.settings."10-shb-nextcloud" = {
+        "/srv/nextcloud".d = {
+          mode = "0750";
+          user = "nextcloud";
+          group = "nextcloud";
+        };
+        "/run/nextcloud-instanceid".f = {
+          mode = "0400";
+          user = "nextcloud";
+          group = "nextcloud";
+          argument = "oc12345abcde";
+        };
+      };
       services.nextcloud.secrets.instanceid = "/run/nextcloud-instanceid";
 
       shb.nextcloud = {
@@ -387,9 +396,13 @@ let
     };
 
   externalstorage = {
-    systemd.tmpfiles.rules = [
-      "d '/srv/nextcloud' 0750 nextcloud nextcloud - -"
-    ];
+    systemd.tmpfiles.settings."10-shb-nextcloud" = {
+      "/srv/nextcloud".d = {
+        mode = "0750";
+        user = "nextcloud";
+        group = "nextcloud";
+      };
+    };
 
     shb.nextcloud = {
       apps.externalStorage = {
@@ -403,9 +416,13 @@ let
   memories =
     { config, ... }:
     {
-      systemd.tmpfiles.rules = [
-        "d '/srv/nextcloud' 0750 nextcloud nextcloud - -"
-      ];
+      systemd.tmpfiles.settings."10-shb-nextcloud" = {
+        "/srv/nextcloud".d = {
+          mode = "0750";
+          user = "nextcloud";
+          group = "nextcloud";
+        };
+      };
 
       shb.nextcloud = {
         apps.memories.enable = true;
@@ -416,9 +433,13 @@ let
   recognize =
     { config, ... }:
     {
-      systemd.tmpfiles.rules = [
-        "d '/srv/nextcloud' 0750 nextcloud nextcloud - -"
-      ];
+      systemd.tmpfiles.settings."10-shb-nextcloud" = {
+        "/srv/nextcloud".d = {
+          mode = "0750";
+          user = "nextcloud";
+          group = "nextcloud";
+        };
+      };
 
       shb.nextcloud = {
         apps.recognize.enable = true;

--- a/test/services/pinchflat.nix
+++ b/test/services/pinchflat.nix
@@ -36,9 +36,13 @@ let
         secretKeyBase.result = config.shb.hardcodedsecret.secretKeyBase.result;
       };
 
-      systemd.tmpfiles.rules = [
-        "d '/src/pinchflat' 0750 pinchflat pinchflat - -"
-      ];
+      systemd.tmpfiles.settings."10-shb-pinchflat" = {
+        "/src/pinchflat".d = {
+          mode = "0750";
+          user = "pinchflat";
+          group = "pinchflat";
+        };
+      };
 
       # Needed for gitea-runner-local to be able to ping pinchflat.
       networking.hosts = {


### PR DESCRIPTION
Closes #750

## What

Switches every remaining use of the deprecated `systemd.tmpfiles.rules` list
syntax to the newer `systemd.tmpfiles.settings` attrset syntax, across all 14
files that used it (12 modules/test files with `rules =`, plus the one file
that already had a `settings` block for something else, `mailserver.nix`).

Each conversion keeps the exact same path, type, mode, user and group as
before, so there is no behavior change — this is a pure syntax migration.
Where a group name was needed, I followed the `10-shb-<name>` convention
already used for `systemd.tmpfiles.settings."10-shb-mailserver"` in
`mailserver.nix` before this PR.

One file needed more than a mechanical swap: `mailserver.nix` already had a
`systemd.tmpfiles.settings."10-shb-mailserver"` block (for the per-account
`mail/` directory) *and* a separate, old-style `systemd.tmpfiles.rules` block
(for the account's parent directories) inside the same `mkIf`. Rather than
add a second `tmpfiles.settings` group next to the first, I merged both sets
of paths into the single existing `"10-shb-mailserver"` group.

## Testing

I don't have a `nix` binary available in the environment I worked in, so I
could not run `nix flake check` or `nix fmt -- --ci` to build-check or
format-check this. I checked it by hand instead: grepped to confirm no
`tmpfiles.rules` remain and no group/path collisions were introduced, and
matched the attrset formatting style already used elsewhere in this repo
(e.g. the existing `mailserver.nix` `10-shb-mailserver` block, and
`restic.nix`'s existing `d = { ... }` blocks). I'd appreciate a maintainer
or CI double-checking the build and formatter output, since I can't confirm
either locally.

Marking this AI-assisted: this PR was authored by an AI coding agent
(Claude).
