### PR TITLE
ci: authenticate lock update pushes with update token

### DIFF
--- a/.github/workflows/lock-update.yaml
+++ b/.github/workflows/lock-update.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:


### PR DESCRIPTION
actions/checkout otherwise persists GITHUB_TOKEN for subsequent Git operations. Use the existing update token for checkout so automated PR updates trigger CI without requiring manual workflow approval.