### PR TITLE
update nixpkgs to 2fcb964de67fcf60b43471c55d5d99e61a9ccb5a

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
-        "owner": "nixos",
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/f13ff45afd1bb73e640eaa08a7066dbed07e3238...2fcb964de67fcf60b43471c55d5d99e61a9ccb5a