### PR TITLE
update nixpkgs to 5747f8e44e7cca7e7652cf52e20817fa1353c6a1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786514691,
-        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
+        "lastModified": 1786433064,
+        "narHash": "sha256-iug43mAUw3DVCZXjQCaulVCsg2WhcnlfN/zzS/+lo4w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
+        "rev": "5747f8e44e7cca7e7652cf52e20817fa1353c6a1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786384358,
-        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/2fcb964de67fcf60b43471c55d5d99e61a9ccb5a...867dcbc30bafe3c862ef88620f2e7a109d7d3be5 ❌
 - https://github.com/NixOS/nixpkgs/compare/2fcb964de67fcf60b43471c55d5d99e61a9ccb5a...5747f8e44e7cca7e7652cf52e20817fa1353c6a1 (bisected in the past)