### PR TITLE
update nixpkgs to b0272a09f74286ce34843d31166da5664006a40e

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786514691,
-        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
+        "lastModified": 1786490192,
+        "narHash": "sha256-PGrhEw0jgvr/ybng6nTpFq5C5r9urNKj9ViHFIwXE70=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
+        "rev": "c62af056f0254dfdbd8ac6729fbe0e9c690345e9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786433064,
-        "narHash": "sha256-iug43mAUw3DVCZXjQCaulVCsg2WhcnlfN/zzS/+lo4w=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5747f8e44e7cca7e7652cf52e20817fa1353c6a1",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786490192,
-        "narHash": "sha256-PGrhEw0jgvr/ybng6nTpFq5C5r9urNKj9ViHFIwXE70=",
+        "lastModified": 1786486787,
+        "narHash": "sha256-Hy46hk1sMsgimELbfkxBuGQca36IXHEn56KbZDMEAmk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c62af056f0254dfdbd8ac6729fbe0e9c690345e9",
+        "rev": "b0272a09f74286ce34843d31166da5664006a40e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/5747f8e44e7cca7e7652cf52e20817fa1353c6a1...867dcbc30bafe3c862ef88620f2e7a109d7d3be5 ❌
 - https://github.com/NixOS/nixpkgs/compare/5747f8e44e7cca7e7652cf52e20817fa1353c6a1...c62af056f0254dfdbd8ac6729fbe0e9c690345e9 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/5747f8e44e7cca7e7652cf52e20817fa1353c6a1...b0272a09f74286ce34843d31166da5664006a40e (bisected in the past)