### PR TITLE
update nixpkgs to 0e251e24a4f24e036a084b6b4b2d2491af4167f4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786486787,
-        "narHash": "sha256-Hy46hk1sMsgimELbfkxBuGQca36IXHEn56KbZDMEAmk=",
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0272a09f74286ce34843d31166da5664006a40e",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/b0272a09f74286ce34843d31166da5664006a40e...0e251e24a4f24e036a084b6b4b2d2491af4167f4