### PR TITLE
modules: remove redundant upstream defaults

### DIFF
--- a/modules/blocks/borgbackup.nix
+++ b/modules/blocks/borgbackup.nix
@@ -299,8 +299,6 @@ in
                 # We do not set encryption.passphrase here, we set BORG_PASSPHRASE_FD further down.
                 encryption.passCommand = "cat ${instance.settings.passphrase.result.path}";
 
-                doInit = true;
-                failOnWarnings = true;
                 stateDir = instance.settings.stateDir;
 
                 persistentTimer = instance.settings.repository.timerConfig.Persistent or false;
@@ -344,8 +342,6 @@ in
                 # We do not set encryption.passphrase here, we set BORG_PASSPHRASE_FD further down.
                 encryption.passCommand = "cat ${instance.settings.passphrase.result.path}";
 
-                doInit = true;
-                failOnWarnings = true;
                 stateDir = instance.settings.stateDir;
 
                 persistentTimer = instance.settings.repository.timerConfig.Persistent or false;

--- a/modules/blocks/davfs.nix
+++ b/modules/blocks/davfs.nix
@@ -102,7 +102,6 @@ in
     systemd.mounts =
       let
         mkMountCfg = c: {
-          enable = true;
           description = "Webdav mount point";
           after = [ "network-online.target" ];
           wants = [ "network-online.target" ];

--- a/modules/blocks/monitoring.nix
+++ b/modules/blocks/monitoring.nix
@@ -486,7 +486,6 @@ in
 
       services.loki = {
         enable = true;
-        dataDir = "/var/lib/loki";
         package =
           if cfg.lokiMajorVersion == 3 then
             pkgs.grafana-loki
@@ -925,8 +924,6 @@ in
       services.scrutiny = {
         enable = true;
 
-        openFirewall = false;
-
         # This src includes Prometheus metrics exporter.
         package = pkgs.scrutiny.overrideAttrs ({
           src = pkgs.fetchFromGitHub {
@@ -946,9 +943,6 @@ in
           };
         };
 
-        collector = {
-          enable = true;
-        };
       };
 
       services.prometheus.scrapeConfigs = [

--- a/modules/blocks/restic.nix
+++ b/modules/blocks/restic.nix
@@ -293,7 +293,6 @@ in
                 passwordFile = toString instance.settings.passphrase.result.path;
 
                 initialize = true;
-                createWrapper = true;
                 environmentFile = lib.mkIf (
                   instance.settings.repository.secrets != { }
                 ) "/run/secrets_restic/${fullName name instance.settings.repository}";
@@ -337,7 +336,6 @@ in
                 passwordFile = toString instance.settings.passphrase.result.path;
 
                 initialize = true;
-                createWrapper = true;
                 environmentFile = lib.mkIf (
                   instance.settings.repository.secrets != { }
                 ) "/run/secrets_restic/${fullName name instance.settings.repository}";

--- a/modules/blocks/vpn.nix
+++ b/modules/blocks/vpn.nix
@@ -278,8 +278,6 @@ in
           name: c:
           lib.mkIf c.enable {
             ${name} = {
-              autoStart = true;
-
               up = "mkdir -p /run/openvpn/${name}";
 
               config = nordvpnConfig {

--- a/modules/services/audiobookshelf.nix
+++ b/modules/services/audiobookshelf.nix
@@ -175,14 +175,11 @@ in
         services.audiobookshelf = {
           enable = true;
           openFirewall = true;
-          dataDir = "audiobookshelf";
-          host = "127.0.0.1";
           port = cfg.webPort;
         };
 
         services.nginx.enable = true;
         services.nginx.virtualHosts."${fqdn}" = {
-          http2 = true;
           forceSSL = !(isNull cfg.ssl);
           sslCertificate = lib.mkIf (!(isNull cfg.ssl)) cfg.ssl.paths.cert;
           sslCertificateKey = lib.mkIf (!(isNull cfg.ssl)) cfg.ssl.paths.key;

--- a/modules/services/firefly-iii.nix
+++ b/modules/services/firefly-iii.nix
@@ -319,7 +319,6 @@ in
       {
         services.firefly-iii = {
           enable = true;
-          group = "nginx";
 
           virtualHost = "${cfg.subdomain}.${cfg.domain}";
 

--- a/modules/services/hledger.nix
+++ b/modules/services/hledger.nix
@@ -108,7 +108,6 @@ in
       stateDir = cfg.dataDir;
       journalFiles = [ "hledger.journal" ];
 
-      host = "127.0.0.1";
       port = cfg.port;
 
       allow = "edit";

--- a/modules/services/home-assistant.nix
+++ b/modules/services/home-assistant.nix
@@ -242,7 +242,6 @@ in
         "met"
         "radio_browser"
       ];
-      configDir = "/var/lib/hass";
       # If you can't find a component in component-packages.nix, you can add them manually with something similar to:
       # extraPackages = python3Packages: [
       #   (python3Packages.simplisafe-python.overrideAttrs (old: rec {
@@ -362,8 +361,6 @@ in
     services.wyoming.openwakeword = cfg.voice.wakeword;
 
     services.nginx.virtualHosts."${fqdn}" = {
-      http2 = true;
-
       forceSSL = !(isNull cfg.ssl);
       sslCertificate = lib.mkIf (!(isNull cfg.ssl)) cfg.ssl.paths.cert;
       sslCertificateKey = lib.mkIf (!(isNull cfg.ssl)) cfg.ssl.paths.key;

--- a/modules/services/homepage.nix
+++ b/modules/services/homepage.nix
@@ -230,11 +230,7 @@ in
         disableUpdateCheck = true;
       };
 
-      bookmarks = [ ];
-
       services = shb.homepage.asServiceGroup cfg.servicesGroups;
-
-      widgets = [ ];
     };
 
     systemd.services.homepage-dashboard.serviceConfig =

--- a/modules/services/jellyfin.nix
+++ b/modules/services/jellyfin.nix
@@ -379,8 +379,6 @@ in
       sslCertificate = lib.mkIf (!(isNull cfg.ssl)) cfg.ssl.paths.cert;
       sslCertificateKey = lib.mkIf (!(isNull cfg.ssl)) cfg.ssl.paths.key;
 
-      http2 = true;
-
       extraConfig = ''
         # The default `client_max_body_size` is 1M, this might not be enough for some posters, etc.
         client_max_body_size 20M;

--- a/modules/services/karakeep.nix
+++ b/modules/services/karakeep.nix
@@ -197,7 +197,6 @@ in
       (lib.mkIf cfg.enable {
         services.karakeep = {
           enable = true;
-          meilisearch.enable = true;
           # Node 24.19 can abort ObjectWrap addons during GC. Use the supported
           # Node 22 LTS until a fixed Node 24 reaches nixpkgs.
           # https://github.com/nodejs/node/issues/65446

--- a/modules/services/mailserver.nix
+++ b/modules/services/mailserver.nix
@@ -433,8 +433,6 @@ in
 
         localDnsResolver = false;
 
-        enableImapSsl = true;
-        enableSubmissionSsl = true;
         x509 = {
           certificateFile = cfg.ssl.paths.cert;
           privateKeyFile = cfg.ssl.paths.key;

--- a/modules/services/nextcloud-server.nix
+++ b/modules/services/nextcloud-server.nix
@@ -774,9 +774,6 @@ in
         };
         database.createLocally = true;
 
-        # Enable caching using redis https://nixos.wiki/wiki/Nextcloud#Caching.
-        configureRedis = true;
-
         # Adds appropriate nginx rewrite rules.
         webfinger = true;
 
@@ -784,7 +781,6 @@ in
         https = !(isNull cfg.ssl);
 
         extraApps = if isNull cfg.extraApps then { } else cfg.extraApps nextcloudApps;
-        extraAppsEnable = true;
 
         settings =
           let

--- a/modules/services/open-webui.nix
+++ b/modules/services/open-webui.nix
@@ -189,7 +189,6 @@ in
         services.open-webui = {
           enable = true;
 
-          host = "127.0.0.1";
           inherit (cfg) port;
 
           environment = {

--- a/modules/services/paperless.nix
+++ b/modules/services/paperless.nix
@@ -375,7 +375,6 @@ in
     # Configure paperless service
     services.paperless = {
       enable = true;
-      address = "127.0.0.1";
       port = cfg.port;
       consumptionDirIsPublic = true;
       dataDir = cfg.dataDir;


### PR DESCRIPTION
## Summary

- Remove 38 option assignments that duplicate defaults from the pinned upstream modules.
- Keep SHB behavior unchanged while reducing configuration that must be maintained across upstream changes.

## Validation

Derivation paths were evaluated sequentially for this commit and its parent to avoid retaining the full check graph in one Nix evaluator:

- All 138 `checks.x86_64-linux` derivation paths are identical.
- Of the five `packages.x86_64-linux` derivation paths, only `manualHtml` and `generateRedirects` differ.
- `nix-diff` reports that the only difference in those documentation packages is the repository source store path, which necessarily changes between Git revisions.

The following script reproduces the comparison:

```python
from __future__ import annotations

import json
import subprocess
import sys
from pathlib import Path
from typing import cast

SYSTEM = "x86_64-linux"
EXPECTED_PACKAGE_CHANGES = {"manualHtml", "generateRedirects"}


def output(*args: str) -> str:
    completed: subprocess.CompletedProcess[str] = subprocess.run(
        args,
        check=True,
        stdout=subprocess.PIPE,
        text=True,
    )
    return completed.stdout.strip()


def flake_attribute(repo: Path, revision: str, attribute: str) -> str:
    flake = f"git+{repo.as_uri()}?rev={revision}"
    return f"{flake}#{attribute}"


def attribute_names(attribute: str) -> list[str]:
    parsed: object = json.loads(
        output(
            "nix",
            "eval",
            "--json",
            attribute,
            "--apply",
            "builtins.attrNames",
        )
    )
    if not isinstance(parsed, list) or not all(
        isinstance(name, str) for name in parsed
    ):
        raise TypeError("nix eval returned an invalid attribute-name list")

    return cast(list[str], parsed)


def derivation_path(attribute: str, name: str) -> str:
    expression = f"attrs: (builtins.getAttr {json.dumps(name)} attrs).drvPath"
    return output(
        "nix",
        "eval",
        "--raw",
        attribute,
        "--apply",
        expression,
    )


def evaluate_drv_paths(
    repo: Path,
    base_revision: str,
    head_revision: str,
    attribute: str,
) -> tuple[dict[str, str], dict[str, str]]:
    base_attribute = flake_attribute(repo, base_revision, attribute)
    head_attribute = flake_attribute(repo, head_revision, attribute)
    base_names = attribute_names(base_attribute)
    head_names = attribute_names(head_attribute)

    assert base_names == head_names, (
        f"{attribute} names differ:\n"
        f"base: {base_names!r}\n"
        f"head: {head_names!r}"
    )

    base_derivations: dict[str, str] = {}
    head_derivations: dict[str, str] = {}

    for base_name, head_name in zip(base_names, head_names, strict=True):
        print(base_name, flush=True)

        base_drv_path = derivation_path(base_attribute, base_name)
        base_derivations[base_name] = base_drv_path
        print(f"  base: {base_drv_path}", flush=True)

        head_drv_path = derivation_path(head_attribute, head_name)
        head_derivations[head_name] = head_drv_path
        print(f"  head: {head_drv_path}", flush=True)
        result = "✅ match" if base_drv_path == head_drv_path else "❌ different"
        print(f"  {result}", flush=True)

    return base_derivations, head_derivations


def find_changes(
    before: dict[str, str],
    after: dict[str, str],
) -> dict[str, tuple[str | None, str | None]]:
    return {
        name: (before.get(name), after.get(name))
        for name in before.keys() | after.keys()
        if before.get(name) != after.get(name)
    }


def main() -> int:
    repo = Path(output("git", "rev-parse", "--show-toplevel"))
    base = output("git", "-C", str(repo), "rev-parse", "HEAD^")
    head = output("git", "-C", str(repo), "rev-parse", "HEAD")

    base_checks, head_checks = evaluate_drv_paths(
        repo,
        base,
        head,
        f"checks.{SYSTEM}",
    )
    check_changes = find_changes(base_checks, head_checks)

    if check_changes:
        print("Changed check derivations:", file=sys.stderr)
        for name, (before, after) in sorted(check_changes.items()):
            print(f"{name}:\n- {before}\n+ {after}", file=sys.stderr)
        return 1

    print(f"All {len(base_checks)} check derivations are identical.")

    base_packages, head_packages = evaluate_drv_paths(
        repo,
        base,
        head,
        f"packages.{SYSTEM}",
    )
    package_changes = find_changes(base_packages, head_packages)

    if package_changes.keys() != EXPECTED_PACKAGE_CHANGES:
        print(
            f"Unexpected package changes: {sorted(package_changes)}",
            file=sys.stderr,
        )
        return 1

    for package in sorted(EXPECTED_PACKAGE_CHANGES):
        before, after = package_changes[package]
        assert before is not None and after is not None
        subprocess.run(
            ["nix", "run", "nixpkgs#nix-diff", "--", before, after],
            check=True,
        )

    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```

Run it via `python3 -c '<paste script here>'`.