### PR TITLE
update nixpkgs to 4b9be8f594aab47b153432b985000a8cc5675139

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786599213,
-        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786720053,
-        "narHash": "sha256-pUNZAgSB7J8jGoOrCaMqQWAiZ7PPfppM0xUxa1tTaQ0=",
+        "lastModified": 1786656043,
+        "narHash": "sha256-yqzFZr22aeKPjRcGiF4U1X7KrocAwrCniQ98VPcUY38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f949d706e59a2addecce8a407904bd2459efe941",
+        "rev": "4b9be8f594aab47b153432b985000a8cc5675139",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786862985,
-        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
+        "lastModified": 1786720053,
+        "narHash": "sha256-pUNZAgSB7J8jGoOrCaMqQWAiZ7PPfppM0xUxa1tTaQ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
+        "rev": "f949d706e59a2addecce8a407904bd2459efe941",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/0e251e24a4f24e036a084b6b4b2d2491af4167f4...e5bdc4a41d4c072fe1e3787eaa0320a384741d44 ❌
 - https://github.com/NixOS/nixpkgs/compare/0e251e24a4f24e036a084b6b4b2d2491af4167f4...f949d706e59a2addecce8a407904bd2459efe941 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/0e251e24a4f24e036a084b6b4b2d2491af4167f4...4b9be8f594aab47b153432b985000a8cc5675139 (bisected in the past)