### PR TITLE
update nixpkgs to e5bdc4a41d4c072fe1e3787eaa0320a384741d44

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786656043,
-        "narHash": "sha256-yqzFZr22aeKPjRcGiF4U1X7KrocAwrCniQ98VPcUY38=",
+        "lastModified": 1786862985,
+        "narHash": "sha256-FBJRXmbGXiSUDvYEbfLYRkckayyZ6SK1UEqhCrIZ2Cs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4b9be8f594aab47b153432b985000a8cc5675139",
+        "rev": "e5bdc4a41d4c072fe1e3787eaa0320a384741d44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/4b9be8f594aab47b153432b985000a8cc5675139...e5bdc4a41d4c072fe1e3787eaa0320a384741d44