### PR TITLE
update nixpkgs to 6c62d5ce6682066c5dbd0035e377cc145e00d50b

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786878062,
-        "narHash": "sha256-RxIPhlw5G0IwPje+EfK3LHqwfN3nd4JAM3ZXJZ4jCdI=",
+        "lastModified": 1787001381,
+        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15e016c09b5b29c6700b58410e771feed4a2e172",
+        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787001381,
-        "narHash": "sha256-Ue1Yo8gfHdD4TMtNewhA4tkSYeFqXThju0nCyJc3ALo=",
+        "lastModified": 1786919944,
+        "narHash": "sha256-MZVImYfbQe4u9A4XcQCSAv4jlsiYWml1MEy00kGBSTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ec2d622de0773551768cf98f3fc50cbcc003b9c5",
+        "rev": "6c62d5ce6682066c5dbd0035e377cc145e00d50b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/15e016c09b5b29c6700b58410e771feed4a2e172...ec2d622de0773551768cf98f3fc50cbcc003b9c5 ❌
 - https://github.com/NixOS/nixpkgs/compare/15e016c09b5b29c6700b58410e771feed4a2e172...6c62d5ce6682066c5dbd0035e377cc145e00d50b (bisected in the past)