### PR TITLE
update nixpkgs to f4b6996c4e8b9ee06ce147ec344c885f51071b14

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786996176,
-        "narHash": "sha256-4U3V7dJo4UEOEgzFyymyYUPY3CV0GcaLGvj82pb1yvo=",
+        "lastModified": 1786963906,
+        "narHash": "sha256-3tkeMWSvHPo3tYljfXbPC/TgknikU1GvdVr/DkdfvE0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d62ceecd35dcfc3cde26ae61ba4aa3aa8eedf58",
+        "rev": "f4b6996c4e8b9ee06ce147ec344c885f51071b14",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786919944,
-        "narHash": "sha256-MZVImYfbQe4u9A4XcQCSAv4jlsiYWml1MEy00kGBSTM=",
+        "lastModified": 1787070829,
+        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c62d5ce6682066c5dbd0035e377cc145e00d50b",
+        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787070829,
-        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
+        "lastModified": 1786996176,
+        "narHash": "sha256-4U3V7dJo4UEOEgzFyymyYUPY3CV0GcaLGvj82pb1yvo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
+        "rev": "0d62ceecd35dcfc3cde26ae61ba4aa3aa8eedf58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/6c62d5ce6682066c5dbd0035e377cc145e00d50b...0ae2bc1419c3f345984c2629e72e7a631820fa4d ❌
 - https://github.com/NixOS/nixpkgs/compare/6c62d5ce6682066c5dbd0035e377cc145e00d50b...0d62ceecd35dcfc3cde26ae61ba4aa3aa8eedf58 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/6c62d5ce6682066c5dbd0035e377cc145e00d50b...f4b6996c4e8b9ee06ce147ec344c885f51071b14 (bisected in the past)