### PR TITLE
update nixpkgs to ffb3c9b700e759be2ef13237c9d8f953b32a1e46

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787070829,
-        "narHash": "sha256-vXNVDVtvfiQuXthP0NHPFdNvvMTkGpx0UP8oddIWbNk=",
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ae2bc1419c3f345984c2629e72e7a631820fa4d",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/0ae2bc1419c3f345984c2629e72e7a631820fa4d...ffb3c9b700e759be2ef13237c9d8f953b32a1e46