### PR TITLE
postgresql: own server major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Template:
 
 ## Breaking Changes
 
+- Require `shb.postgresql.version` when PostgreSQL is enabled. Existing
+  deployments must first set it to their currently running PostgreSQL major.
+  This does not perform an automatic major upgrade; guarded forward major-version
+  upgrade helpers are provided for later explicit upgrades. PostgreSQL backup
+  and restore commands now use tools matching the configured server version
+  ([issue #829](https://github.com/ibizaman/selfhostblocks/issues/829)).
 - Nextcloud 33 and 34 are now supported, replacing versions 32 and 33. The default is now 33.
   Deploy version 33 before selecting version 34 because Nextcloud does not support skipping major versions.
 - Remove the ignored `shb.zfs.pools.<pool>.datasets.<dataset>.enable` option.

--- a/demo/jellyfin/flake.nix
+++ b/demo/jellyfin/flake.nix
@@ -129,6 +129,8 @@
             selfhostblocks.nixosModules.authelia
           ];
 
+          shb.postgresql.version = 18;
+
           shb.authelia = {
             enable = true;
             domain = "example.com";

--- a/demo/nextcloud/flake.nix
+++ b/demo/nextcloud/flake.nix
@@ -31,6 +31,8 @@
 
           sops.defaultSopsFile = ./secrets.yaml;
 
+          shb.postgresql.version = 18;
+
           shb.nextcloud = {
             enable = true;
             domain = "example.com";

--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -1391,11 +1391,20 @@
   "blocks-postgresql-options-shb.postgresql.ensures._.username": [
     "blocks-postgresql.html#blocks-postgresql-options-shb.postgresql.ensures._.username"
   ],
+  "blocks-postgresql-options-shb.postgresql.version": [
+    "blocks-postgresql.html#blocks-postgresql-options-shb.postgresql.version"
+  ],
   "blocks-postgresql-tests": [
     "blocks-postgresql.html#blocks-postgresql-tests"
   ],
+  "blocks-postgresql-upgrade": [
+    "blocks-postgresql.html#blocks-postgresql-upgrade"
+  ],
   "blocks-postgresql-usage": [
     "blocks-postgresql.html#blocks-postgresql-usage"
+  ],
+  "blocks-postgresql-version": [
+    "blocks-postgresql.html#blocks-postgresql-version"
   ],
   "blocks-restic": [
     "blocks-restic.html#blocks-restic"

--- a/modules/blocks/postgresql.nix
+++ b/modules/blocks/postgresql.nix
@@ -8,35 +8,112 @@
 let
   cfg = config.shb.postgresql;
 
-  upgrade-script =
+  # The fallback supports the manual's isolated option evaluation.
+  postgresqlPackage = config.services.postgresql.finalPackage or pkgs.postgresql;
+
+  supportedVersions = [
+    15
+    16
+    17
+    18
+  ];
+  supportedVersionPattern = lib.concatStringsSep "|" (map toString supportedVersions);
+
+  packageForVersion = version: pkgs.${"postgresql_${toString version}"};
+
+  upgradeScript =
     old: new:
     let
       oldStr = builtins.toString old;
       newStr = builtins.toString new;
 
-      oldPkg = pkgs.${"postgresql_${oldStr}"};
-      newPkg = pkgs.${"postgresql_${newStr}"};
+      oldPkg = packageForVersion old;
+      newPkg = packageForVersion new;
     in
-    pkgs.writeScriptBin "upgrade-pg-cluster-${oldStr}-${newStr}" ''
-      set -eux
-      # XXX it's perhaps advisable to stop all services that depend on postgresql
-      systemctl stop postgresql
+    pkgs.writeShellApplication {
+      name = "upgrade-pg-cluster-${oldStr}-${newStr}";
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.gnused
+        pkgs.sudo
+        pkgs.systemd
+      ];
+      text = ''
+        # Require root because the helper creates PostgreSQL-owned directories.
+        if [[ "$EUID" -ne 0 ]]; then
+          echo "Run this command as root." >&2
+          exit 1
+        fi
 
-      export NEWDATA="/var/lib/postgresql/${newPkg.psqlSchema}"
-      export NEWBIN="${newPkg}/bin"
+        # Refuse to migrate while the server may still be writing to the source cluster.
+        if systemctl --quiet is-active postgresql.service; then
+          echo "Stop PostgreSQL and its dependent services before upgrading." >&2
+          exit 1
+        fi
 
-      export OLDDATA="/var/lib/postgresql/${oldPkg.psqlSchema}"
-      export OLDBIN="${oldPkg}/bin"
+        # This helper supports only a one-step upgrade.
+        for arg in "$@"; do
+          if [[ "$arg" == "--check" || "$arg" == "-c" ]]; then
+            echo "--check is not supported; run this helper without it to perform the upgrade." >&2
+            exit 1
+          fi
+        done
 
-      install -d -m 0700 -o postgres -g postgres "$NEWDATA"
-      cd "$NEWDATA"
-      sudo -u postgres $NEWBIN/initdb -D "$NEWDATA"
+        oldData="/var/lib/postgresql/${oldPkg.psqlSchema}"
+        oldBin="${oldPkg}/bin"
+        newData="/var/lib/postgresql/${newPkg.psqlSchema}"
+        newBin="${newPkg}/bin"
 
-      sudo -u postgres $NEWBIN/pg_upgrade \
-        --old-datadir "$OLDDATA" --new-datadir "$NEWDATA" \
-        --old-bindir $OLDBIN --new-bindir $NEWBIN \
-        "$@"
-    '';
+        # Require the source cluster's version marker.
+        if [[ ! -f "$oldData/PG_VERSION" ]]; then
+          echo "PostgreSQL ${oldStr} cluster not found at $oldData." >&2
+          exit 1
+        fi
+
+        read -r oldVersion < "$oldData/PG_VERSION"
+        # Verify that the source cluster matches this helper's source version.
+        if [[ "$oldVersion" != "${oldStr}" ]]; then
+          echo "Expected PostgreSQL ${oldStr} at $oldData, found version $oldVersion." >&2
+          exit 1
+        fi
+
+        # Require a missing target path, including when a dangling symlink occupies it.
+        if [[ -e "$newData" || -L "$newData" ]]; then
+          echo "$newData already exists; make sure it is empty, delete it, and rerun the upgrade script." >&2
+          exit 1
+        fi
+
+        # PostgreSQL 18 enables checksums by default, but pg_upgrade requires both clusters to match.
+        checksumVersion="$(
+          "$oldBin/pg_controldata" "$oldData" \
+            | sed -n 's/^Data page checksum version:[[:space:]]*//p'
+        )"
+        initdbArgs=(--pgdata="$newData")
+        case "$checksumVersion" in
+          0)
+            ${lib.optionalString (new >= 18) "initdbArgs+=(--no-data-checksums)"}
+            ;;
+          1) initdbArgs+=(--data-checksums) ;;
+          *)
+            echo "Could not determine the checksum setting of $oldData." >&2
+            exit 1
+            ;;
+        esac
+
+        install -d -m 0700 -o postgres -g postgres "$newData"
+        # Expand each initdb argument without joining or word splitting.
+        sudo --user=postgres "$newBin/initdb" "''${initdbArgs[@]}"
+
+        cd "$newData"
+        # Forward caller-supplied pg_upgrade options without joining or word splitting.
+        exec sudo --user=postgres "$newBin/pg_upgrade" \
+          --old-datadir="$oldData" \
+          --new-datadir="$newData" \
+          --old-bindir="$oldBin" \
+          --new-bindir="$newBin" \
+          "$@"
+      '';
+    };
 in
 {
   imports = [
@@ -44,6 +121,18 @@ in
   ];
 
   options.shb.postgresql = {
+    version = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum supportedVersions);
+      default = null;
+      example = 18;
+      description = ''
+        PostgreSQL major version managed by SelfHostBlocks. This must be set
+        when PostgreSQL is enabled. The null default produces an evaluation
+        error requiring existing deployments to select their current major and
+        new deployments to choose a supported major.
+      '';
+    };
+
     debug = lib.mkOption {
       type = lib.types.bool;
       description = ''
@@ -73,11 +162,11 @@ in
           backupName = "postgres.sql";
 
           backupCmd = ''
-            ${pkgs.postgresql}/bin/pg_dumpall --clean --if-exists | ${pkgs.gzip}/bin/gzip --rsyncable
+            ${postgresqlPackage}/bin/pg_dumpall --clean --if-exists | ${pkgs.gzip}/bin/gzip --rsyncable
           '';
 
           restoreCmd = ''
-            ${pkgs.gzip}/bin/gunzip | sudo -u postgres ${pkgs.postgresql}/bin/psql
+            ${pkgs.gzip}/bin/gunzip | sudo -u postgres ${postgresqlPackage}/bin/psql
           '';
         };
       };
@@ -178,18 +267,83 @@ in
         lib.mkIf enableDebug {
           services.postgresql.settings.shared_preload_libraries = "auto_explain, pg_stat_statements";
         };
+
+      versionConfig = lib.mkIf (cfg.version != null) {
+        services.postgresql.package = packageForVersion cfg.version;
+
+        systemd.services.postgresql = lib.mkIf config.services.postgresql.enable {
+          preStart = lib.mkBefore ''
+            dataDir=${lib.escapeShellArg config.services.postgresql.dataDir}
+            expectedVersion=${lib.escapeShellArg (toString cfg.version)}
+
+            if [[ -f "$dataDir/PG_VERSION" ]]; then
+              read -r actualVersion < "$dataDir/PG_VERSION"
+              if [[ "$actualVersion" != "$expectedVersion" ]]; then
+                echo "Expected PostgreSQL $expectedVersion at $dataDir, found version $actualVersion." >&2
+                exit 1
+              fi
+            else
+              sourceCount=0
+              for versionFile in /var/lib/postgresql/*/PG_VERSION; do
+                if [[ -f "$versionFile" ]]; then
+                  read -r sourceVersion < "$versionFile"
+                  sourceCount=$((sourceCount + 1))
+                  echo "Found an existing PostgreSQL cluster at ''${versionFile%/PG_VERSION} with version $sourceVersion." >&2
+                fi
+              done
+
+              if [[ "$sourceCount" -gt 0 ]]; then
+                # systemd creates StateDirectory before running preStart.
+                if [[ -d "$dataDir" && -z "$(ls -A "$dataDir")" ]]; then
+                  echo "Remove the empty target directory $dataDir before running an upgrade helper." >&2
+                fi
+
+                if [[ "$sourceCount" -eq 1 ]]; then
+                  echo "Set shb.postgresql.version to $sourceVersion and deploy before upgrading." >&2
+                  # Only name helpers generated for a supported forward path.
+                  if [[ "$sourceVersion" =~ ^(${supportedVersionPattern})$ ]] && (( sourceVersion < expectedVersion )); then
+                    echo "Then run upgrade-pg-cluster-$sourceVersion-$expectedVersion before selecting PostgreSQL $expectedVersion." >&2
+                  else
+                    echo "No supported forward upgrade helper exists from PostgreSQL $sourceVersion to $expectedVersion." >&2
+                  fi
+                else
+                  echo "Multiple PostgreSQL clusters were found; identify the cluster to upgrade, set shb.postgresql.version to its major, and deploy before upgrading." >&2
+                fi
+                exit 1
+              fi
+            fi
+          '';
+        };
+      };
     in
     lib.mkMerge ([
       commonConfig
+      {
+        assertions = [
+          {
+            assertion = !config.services.postgresql.enable || cfg.version != null;
+            message = ''
+              PostgreSQL is enabled but `shb.postgresql.version` is not set.
+              When upgrading an existing deployment, set it to the existing cluster's major version.
+              For a new deployment, choose a supported major version.
+              See https://shb.skarabox.com/blocks-postgresql.html#blocks-postgresql-version.
+            '';
+          }
+        ];
+      }
       (dbConfig cfg.ensures)
       (pwdConfig cfg.ensures)
       (lib.mkIf cfg.enableTCPIP tcpConfig)
       (debugConfig cfg.debug)
+      versionConfig
       {
-        environment.systemPackages = lib.mkIf config.services.postgresql.enable [
-          (upgrade-script 15 16)
-          (upgrade-script 16 17)
-        ];
+        environment.systemPackages =
+          lib.optionals (config.services.postgresql.enable && cfg.version != null)
+            (
+              map (upgradeScript cfg.version) (
+                builtins.filter (targetVersion: targetVersion > cfg.version) supportedVersions
+              )
+            );
       }
     ]);
 }

--- a/modules/blocks/postgresql/docs/default.md
+++ b/modules/blocks/postgresql/docs/default.md
@@ -11,8 +11,27 @@ Compared to the upstream nixpkgs module, this module also sets up:
 - Enabling TCP/IP login and also accepting password authentication from localhost with [`shb.postgresql.enableTCPIP`](#blocks-postgresql-options-shb.postgresql.enableTCPIP).
 - Enhance the `ensure*` upstream option by setting up a database's password from a password file with [`shb.postgresql.ensures`](#blocks-postgresql-options-shb.postgresql.ensures).
 - Debug logging with `auto_explain` and `pg_stat_statements` with [`shb.postgresql.debug`](#blocks-postgresql-options-shb.postgresql.debug).
+- Explicit PostgreSQL major-version selection with [`shb.postgresql.version`](#blocks-postgresql-options-shb.postgresql.version).
 
 ## Usage {#blocks-postgresql-usage}
+
+### Select a PostgreSQL Version {#blocks-postgresql-version}
+
+SelfHostBlocks requires an explicit PostgreSQL major version:
+
+```nix
+shb.postgresql.version = 18;
+```
+
+Supported versions are 15, 16, 17, and 18. The server, data directory, backup
+tools, and restore tools all follow this selection.
+
+When first updating an existing deployment, inspect the running server or its
+`PG_VERSION` file and set this option to that same major before rebuilding.
+Leaving the option at its `null` default while PostgreSQL is enabled produces
+an evaluation error. Setting the option does not upgrade the database. If SHB
+finds a cluster for a different PostgreSQL major, it refuses to initialize a
+new cluster and reports the required migration steps.
 
 ### Ensure User and Database {#blocks-postgresql-ensures}
 
@@ -38,6 +57,37 @@ shb.postgresql.ensures = [
   }
 ];
 ```
+
+### Upgrade PostgreSQL {#blocks-postgresql-upgrade}
+
+[PostgreSQL supports upgrading directly to a newer major version without
+installing intervening versions](https://www.postgresql.org/docs/current/upgrading.html).
+For example, to upgrade directly from version 15 to 18:
+
+1. Set `shb.postgresql.version = 15;` and deploy so the source version is
+   explicit.
+2. Stop services that use PostgreSQL so they cannot write to the source cluster.
+3. Take and verify a database backup.
+4. Stop `postgresql.service`.
+5. Run `sudo upgrade-pg-cluster-15-18`.
+6. Set `shb.postgresql.version = 18;` and deploy. This starts PostgreSQL and may
+   also start or restart database consumers affected by the deployment. To
+   validate the target cluster before consumers start, temporarily disable them
+   in the configuration used for this deployment and re-enable them afterwards.
+7. Validate all database consumers and take a fresh backup before manually
+   deleting `/var/lib/postgresql/15`.
+
+The helper performs a one-step upgrade and does not support `--check`.
+`pg_upgrade` checks cluster compatibility before upgrading. The helper refuses
+to run while PostgreSQL is active or if the target path already exists. It does
+not delete or modify the source cluster, and it preserves `pg_upgrade`'s
+standard follow-up output.
+
+SHB provides a helper from the configured version to every newer supported
+version. For example, version 15 provides `upgrade-pg-cluster-15-16`,
+`upgrade-pg-cluster-15-17`, and `upgrade-pg-cluster-15-18`. Read the migration
+notes for every intervening PostgreSQL release and verify application and
+extension compatibility before upgrading.
 
 ### Database Backup Requester Contracts {#blocks-postgresql-contract-databasebackup}
 

--- a/test/blocks/authelia.nix
+++ b/test/blocks/authelia.nix
@@ -29,6 +29,8 @@ in
           ];
         };
 
+        shb.postgresql.version = 18;
+
         shb.certs.cas.selfsigned.myca = {
           name = "My CA";
         };

--- a/test/blocks/postgresql.nix
+++ b/test/blocks/postgresql.nix
@@ -6,6 +6,7 @@
 }:
 let
   pkgs' = pkgs;
+  testPostgresqlVersion = 18;
 in
 {
   peerWithoutUser = shb.test.runNixOSTest {
@@ -20,12 +21,15 @@ in
           ../../modules/blocks/postgresql.nix
         ];
 
-        shb.postgresql.ensures = [
-          {
-            username = "me-with-special-chars";
-            database = "me-with-special-chars";
-          }
-        ];
+        shb.postgresql = {
+          version = testPostgresqlVersion;
+          ensures = [
+            {
+              username = "me-with-special-chars";
+              database = "me-with-special-chars";
+            }
+          ];
+        };
       };
 
     testScript =
@@ -68,12 +72,15 @@ in
         };
         users.groups.me = { };
 
-        shb.postgresql.ensures = [
-          {
-            username = "me";
-            database = "me";
-          }
-        ];
+        shb.postgresql = {
+          version = testPostgresqlVersion;
+          ensures = [
+            {
+              username = "me";
+              database = "me";
+            }
+          ];
+        };
       };
 
     testScript =
@@ -115,13 +122,16 @@ in
           ../../modules/blocks/postgresql.nix
         ];
 
-        shb.postgresql.enableTCPIP = true;
-        shb.postgresql.ensures = [
-          {
-            username = "me";
-            database = "me";
-          }
-        ];
+        shb.postgresql = {
+          version = testPostgresqlVersion;
+          enableTCPIP = true;
+          ensures = [
+            {
+              username = "me";
+              database = "me";
+            }
+          ];
+        };
       };
 
     testScript =
@@ -171,14 +181,17 @@ in
           system.activationScripts.secret = ''
             echo secretpw > /run/dbsecret
           '';
-          shb.postgresql.enableTCPIP = true;
-          shb.postgresql.ensures = [
-            {
-              username = username;
-              database = username;
-              passwordFile = "/run/dbsecret";
-            }
-          ];
+          shb.postgresql = {
+            version = testPostgresqlVersion;
+            enableTCPIP = true;
+            ensures = [
+              {
+                username = username;
+                database = username;
+                passwordFile = "/run/dbsecret";
+              }
+            ];
+          };
         };
 
       testScript =
@@ -204,4 +217,234 @@ in
               machine.fail(tcpip_cmd("${username}", "${username}", "5432", "oops"), timeout=10)
         '';
     };
+
+  upgrade = shb.test.runNixOSTest {
+    name = "postgresql-upgrade";
+
+    nodes.machine =
+      { config, pkgs, ... }:
+      {
+        imports = [
+          (pkgs'.path + "/nixos/modules/profiles/headless.nix")
+          (pkgs'.path + "/nixos/modules/profiles/qemu-guest.nix")
+          ../../modules/blocks/postgresql.nix
+        ];
+
+        shb.postgresql = {
+          version = 15;
+          ensures = [
+            {
+              username = "upgrade-test";
+              database = "upgrade-test";
+            }
+          ];
+        };
+
+        assertions = [
+          {
+            assertion =
+              config.services.postgresql.finalPackage.psqlSchema == toString config.shb.postgresql.version;
+            message = "The PostgreSQL package must match shb.postgresql.version.";
+          }
+          {
+            assertion =
+              config.services.postgresql.dataDir
+              == "/var/lib/postgresql/${toString config.shb.postgresql.version}";
+            message = "The PostgreSQL data directory must match shb.postgresql.version.";
+          }
+          {
+            assertion = lib.hasPrefix "${config.services.postgresql.finalPackage}/bin/pg_dumpall" config.shb.postgresql.databasebackup.request.backupCmd;
+            message = "The backup command must use the configured PostgreSQL package.";
+          }
+          {
+            assertion = lib.hasSuffix "${config.services.postgresql.finalPackage}/bin/psql\n" config.shb.postgresql.databasebackup.request.restoreCmd;
+            message = "The restore command must use the configured PostgreSQL package.";
+          }
+        ];
+
+        specialisation = {
+          postgresql16.configuration.shb.postgresql.version = lib.mkForce 16;
+          postgresql17.configuration.shb.postgresql.version = lib.mkForce 17;
+          postgresql18.configuration.shb.postgresql.version = lib.mkForce 18;
+        };
+      };
+
+    testScript =
+      { nodes, ... }:
+      let
+        baseSystem = nodes.machine.system.build.toplevel;
+        specialisations = "${baseSystem}/specialisation";
+        switch =
+          version: "${specialisations}/postgresql${toString version}/bin/switch-to-configuration test";
+      in
+      ''
+        start_all()
+        machine.wait_for_unit("postgresql.service")
+        machine.wait_for_open_port(5432)
+
+        with subtest("create data on PostgreSQL 15"):
+            machine.succeed(
+                "sudo -u postgres psql --dbname=postgres "
+                + "--command=\"CREATE TABLE shb_upgrade_marker (value text); "
+                + "INSERT INTO shb_upgrade_marker VALUES ('survives upgrades');\""
+            )
+
+        with subtest("upgrade helper refuses to run while PostgreSQL is active"):
+            machine.fail("upgrade-pg-cluster-15-16")
+            machine.succeed("systemctl is-active --quiet postgresql.service")
+            machine.fail("test -e /var/lib/postgresql/16/PG_VERSION")
+
+        with subtest("changing the version does not initialize a replacement cluster"):
+            machine.execute("${switch 16}")
+            machine.wait_until_fails("systemctl is-active --quiet postgresql.service")
+            machine.succeed(
+                "journalctl --unit=postgresql.service "
+                + "--grep='Found an existing PostgreSQL cluster' --no-pager"
+            )
+            machine.succeed(
+                "journalctl --unit=postgresql.service "
+                + "--grep='Set shb.postgresql.version to 15 and deploy before upgrading' "
+                + "--no-pager"
+            )
+            machine.succeed(
+                "journalctl --unit=postgresql.service "
+                + "--grep='Then run upgrade-pg-cluster-15-16 before selecting PostgreSQL 16' "
+                + "--no-pager"
+            )
+            machine.succeed("test -d /var/lib/postgresql/16")
+            machine.fail("test -e /var/lib/postgresql/16/PG_VERSION")
+            machine.succeed("test -e /var/lib/postgresql/15/PG_VERSION")
+
+            target_error = machine.fail("${baseSystem}/sw/bin/upgrade-pg-cluster-15-16 2>&1")
+            assert "already exists" in target_error
+
+            machine.succeed("${baseSystem}/bin/switch-to-configuration test")
+            machine.succeed("rmdir /var/lib/postgresql/16")
+            machine.succeed("systemctl reset-failed postgresql.service")
+            machine.succeed("systemctl start postgresql.target")
+            machine.wait_for_unit("postgresql.service")
+            machine.wait_for_open_port(5432)
+
+        with subtest("only forward upgrade helpers from the configured version are installed"):
+            machine.succeed("command -v upgrade-pg-cluster-15-16")
+            machine.succeed("command -v upgrade-pg-cluster-15-17")
+            machine.succeed("command -v upgrade-pg-cluster-15-18")
+            machine.fail("command -v upgrade-pg-cluster-16-17")
+
+        def migrate(old_version, new_version, switch_command):
+            machine.succeed("systemctl stop postgresql.service")
+            machine.wait_until_fails("systemctl is-active --quiet postgresql.service")
+
+            upgrade_output = machine.succeed(
+                f"upgrade-pg-cluster-{old_version}-{new_version}"
+            )
+            assert "Upgrade Complete" in upgrade_output
+            assert "delete_old_cluster" in upgrade_output
+
+            machine.succeed(switch_command)
+            machine.wait_for_unit("postgresql.service")
+            machine.wait_for_open_port(5432)
+
+            server_version = machine.succeed(
+                "sudo -u postgres psql --tuples-only --no-align "
+                + "--dbname=postgres --command='SHOW server_version_num'"
+            ).strip()
+            assert server_version.startswith(str(new_version))
+
+            marker = machine.succeed(
+                "sudo -u postgres psql --tuples-only --no-align "
+                + "--dbname=postgres --command='SELECT value FROM shb_upgrade_marker'"
+            ).strip()
+            assert marker == "survives upgrades"
+            machine.succeed(f"test -e /var/lib/postgresql/{old_version}/PG_VERSION")
+
+        with subtest("upgrade from PostgreSQL 15 to 16"):
+            migrate(15, 16, "${switch 16}")
+
+        with subtest("multiple retained clusters do not produce a guessed helper"):
+            machine.execute("${switch 17}")
+            machine.wait_until_fails("systemctl is-active --quiet postgresql.service")
+            machine.succeed(
+                "journalctl --unit=postgresql.service "
+                + "--grep='Multiple PostgreSQL clusters were found' --no-pager"
+            )
+            machine.fail(
+                "journalctl --unit=postgresql.service "
+                + "--grep='upgrade-pg-cluster-15-17' --no-pager"
+            )
+
+            machine.succeed("${switch 16}")
+            machine.succeed("rmdir /var/lib/postgresql/17")
+            machine.wait_for_unit("postgresql.service")
+            machine.wait_for_open_port(5432)
+
+        with subtest("upgrade sequentially through the remaining supported majors"):
+            migrate(16, 17, "${switch 17}")
+            migrate(17, 18, "${switch 18}")
+      '';
+  };
+
+  nonAdjacentUpgrade = shb.test.runNixOSTest {
+    name = "postgresql-non-adjacent-upgrade";
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        imports = [
+          (pkgs'.path + "/nixos/modules/profiles/headless.nix")
+          (pkgs'.path + "/nixos/modules/profiles/qemu-guest.nix")
+          ../../modules/blocks/postgresql.nix
+        ];
+
+        services.postgresql.enable = true;
+        shb.postgresql.version = 15;
+
+        specialisation.postgresql18.configuration.shb.postgresql.version = lib.mkForce 18;
+      };
+
+    testScript =
+      { nodes, ... }:
+      let
+        baseSystem = nodes.machine.system.build.toplevel;
+        switchToPostgresql18 = "${baseSystem}/specialisation/postgresql18/bin/switch-to-configuration test";
+      in
+      ''
+        start_all()
+        machine.wait_for_unit("postgresql.service")
+        machine.wait_for_open_port(5432)
+
+        with subtest("create data on PostgreSQL 15"):
+            machine.succeed(
+                "sudo -u postgres psql --dbname=postgres "
+                + "--command=\"CREATE TABLE shb_upgrade_marker (value text); "
+                + "INSERT INTO shb_upgrade_marker VALUES ('survives upgrade');\""
+            )
+
+        with subtest("upgrade directly from PostgreSQL 15 to 18"):
+            machine.succeed("systemctl stop postgresql.service")
+            machine.wait_until_fails("systemctl is-active --quiet postgresql.service")
+
+            upgrade_output = machine.succeed("upgrade-pg-cluster-15-18")
+            assert "Upgrade Complete" in upgrade_output
+            assert "delete_old_cluster" in upgrade_output
+
+            machine.succeed("${switchToPostgresql18}")
+            machine.succeed("systemctl start postgresql.target")
+            machine.wait_for_unit("postgresql.service")
+            machine.wait_for_open_port(5432)
+
+            server_version = machine.succeed(
+                "sudo -u postgres psql --tuples-only --no-align "
+                + "--dbname=postgres --command='SHOW server_version_num'"
+            ).strip()
+            assert server_version.startswith("18")
+
+            marker = machine.succeed(
+                "sudo -u postgres psql --tuples-only --no-align "
+                + "--dbname=postgres --command='SELECT value FROM shb_upgrade_marker'"
+            ).strip()
+            assert marker == "survives upgrade"
+            machine.succeed("test -e /var/lib/postgresql/15/PG_VERSION")
+      '';
+  };
 }

--- a/test/common.nix
+++ b/test/common.nix
@@ -268,6 +268,9 @@ in
         ];
         shb.nginx.insecureAccessLogWithRequestBody = true;
 
+        # Tests that enable PostgreSQL use an explicit, stable major version.
+        shb.postgresql.version = 18;
+
         networking.hosts = {
           "192.168.1.2" = [
             config.test.fqdn

--- a/test/contracts/databasebackup.nix
+++ b/test/contracts/databasebackup.nix
@@ -33,6 +33,7 @@
     extraConfig =
       { config, database, ... }:
       {
+        shb.postgresql.version = 18;
         shb.postgresql.ensures = [
           {
             inherit database;
@@ -80,6 +81,7 @@
     extraConfig =
       { config, database, ... }:
       {
+        shb.postgresql.version = 18;
         shb.postgresql.ensures = [
           {
             inherit database;


### PR DESCRIPTION
Require enabled PostgreSQL deployments to select their server major explicitly, with a null default that emits migration guidance for existing configurations. Use version-matched backup tools and generate guarded pg_upgrade helpers from the configured source to every newer supported major, including non-adjacent upgrades.

Reject activation against a different existing cluster, and test both sequential upgrades from 15 through 18 and a direct 15-to-18 upgrade without data loss or source deletion.

Fixes https://github.com/ibizaman/selfhostblocks/issues/829.