### PR TITLE
Handle jellyfin SSO login

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -86,6 +86,9 @@ jobs:
         run: |
           cd demo/${{ matrix.demo.name }}
           nix flake update --override-input selfhostblocks ../.. selfhostblocks
+          # This is needed because we ignore the demo/*/flake.lock files in the global .gitignore
+          # If we don't add them to git, next nix call will overwrite the override we just did.
+          git add . -f
           nix \
             --print-build-logs \
             --option keep-going true \

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ result
 result-*
 docs/redirects.json.backup
 .nixos-test-history
+demo/*/flake.lock
 \#*#

--- a/modules/services/jellyfin.nix
+++ b/modules/services/jellyfin.nix
@@ -575,15 +575,11 @@ in
         brandingConfig = pkgs.writeText "branding.xml" ''
           <?xml version="1.0" encoding="utf-8"?>
           <BrandingOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-            <LoginDisclaimer>&lt;a href="https://${cfg.subdomain}.${cfg.domain}/SSO/OID/p/${cfg.sso.provider}" class="raised cancel block emby-button authentik-sso"&gt;
+            <LoginDisclaimer>&lt;a title="Click here if you are a new Jellyfin user or if you already linked your SSO account before" href="https://${cfg.subdomain}.${cfg.domain}/SSO/OID/p/${cfg.sso.provider}" class="raised cancel block emby-button"&gt;
                 Sign in with ${cfg.sso.provider}&amp;nbsp;
-                &lt;img alt="OpenID Connect (authentik)" title="OpenID Connect (authentik)" class="oauth-login-image" src="https://raw.githubusercontent.com/goauthentik/authentik/master/web/icons/icon.png"&gt;
               &lt;/a&gt;
-              &lt;a href="https://${cfg.subdomain}.${cfg.domain}/SSOViews/linking" class="raised cancel block emby-button authentik-sso"&gt;
-                Link ${cfg.sso.provider} config&amp;nbsp;
-              &lt;/a&gt;
-              &lt;a href="${cfg.sso.endpoint}" class="raised cancel block emby-button authentik-sso"&gt;
-                ${cfg.sso.provider} config&amp;nbsp;
+              &lt;a title="Click here if you already logged into Jellyfin with SSO and want to enable SSO" href="https://${cfg.subdomain}.${cfg.domain}/SSOViews/linking" class="raised cancel block emby-button"&gt;
+                Link existing user to ${cfg.sso.provider}&amp;nbsp;
               &lt;/a&gt;
             </LoginDisclaimer>
             <CustomCss>
@@ -601,11 +597,6 @@ in
               /* Let disclaimer take full width */
               .disclaimerContainer {
                  display: block;
-              }
-
-              /* Optionally, apply some styling to the `.authentik-sso` class, probably let users configure this */
-              .authentik-sso {
-                 /* idk set a background image or something lol */
               }
 
               .oauth-login-image {

--- a/modules/services/jellyfin.nix
+++ b/modules/services/jellyfin.nix
@@ -572,14 +572,14 @@ in
           </PluginConfiguration>
         '';
 
+        # In SHB we purposely always redirect to the ?isLinking=true link because
+        # it appears this always does the right thing. It takes care of both
+        # an existing Jellyfin user using SSO for the first time or a new user.
         brandingConfig = pkgs.writeText "branding.xml" ''
           <?xml version="1.0" encoding="utf-8"?>
           <BrandingOptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-            <LoginDisclaimer>&lt;a title="Click here if you are a new Jellyfin user or if you already linked your SSO account before" href="https://${cfg.subdomain}.${cfg.domain}/SSO/OID/p/${cfg.sso.provider}" class="raised cancel block emby-button"&gt;
+            <LoginDisclaimer>&lt;a title="Click here if you are a new Jellyfin user or if you already linked your SSO account before" href="https://${cfg.subdomain}.${cfg.domain}/SSO/oid/p/${cfg.sso.provider}?isLinking=true" class="raised cancel block emby-button"&gt;
                 Sign in with ${cfg.sso.provider}&amp;nbsp;
-              &lt;/a&gt;
-              &lt;a title="Click here if you already logged into Jellyfin with SSO and want to enable SSO" href="https://${cfg.subdomain}.${cfg.domain}/SSOViews/linking" class="raised cancel block emby-button"&gt;
-                Link existing user to ${cfg.sso.provider}&amp;nbsp;
               &lt;/a&gt;
             </LoginDisclaimer>
             <CustomCss>

--- a/modules/services/jellyfin.nix
+++ b/modules/services/jellyfin.nix
@@ -672,6 +672,7 @@ in
         (shb.replaceSecretsScript {
           file = ldapConfig;
           resultPath = "${config.services.jellyfin.dataDir}/plugins/configurations/LDAP-Auth.xml";
+          permissions = "u=rw,g=r,o=";
           replacements = [
             {
               name = [ "LDAP_PASSWORD" ];
@@ -684,6 +685,7 @@ in
         shb.replaceSecretsScript {
           file = ssoConfig;
           resultPath = "${config.services.jellyfin.dataDir}/plugins/configurations/SSO-Auth.xml";
+          permissions = "u=rw,g=r,o=";
           replacements = [
             {
               name = [ "SSO_SECRET" ];

--- a/modules/services/jellyfin/docs/default.md
+++ b/modules/services/jellyfin/docs/default.md
@@ -49,15 +49,15 @@ shb.jellyfin = {
     host = "127.0.0.1";
     port = config.shb.lldap.ldapPort;
     dcdomain = config.shb.lldap.dcdomain;
-    adminPassword.result = config.shb.sops.secret."jellyfin/ldap/adminPassword".result
+    adminPassword.result = config.shb.sops.secret."jellyfin/ldap/adminPassword".result;
   };
 
   sso = {
     enable = true;
     endpoint = "https://${config.shb.authelia.subdomain}.${config.shb.authelia.domain}";
   
-    secretFile = config.shb.sops.secret."jellyfin/sso_secret".result;
-    secretFileForAuthelia = config.shb.sops.secret."jellyfin/authelia/sso_secret".result;
+    sharedSecret.result = config.shb.sops.secret."jellyfin/sso_secret".result;
+    sharedSecretForAuthelia.result = config.shb.sops.secret."jellyfin/authelia/sso_secret".result;
   };
 };
 


### PR DESCRIPTION
Copying here a comment in the code:

> In SHB we purposely always redirect to the ?isLinking=true link because it appears this always does the right thing. It takes care of both an existing Jellyfin user using SSO for the first time or a new user.

Also:

> For a reason I can't explain, the SSO and LDAP plugins both try to write to their respective config files on first use. Since this would fail because of the restrictive permission, first login would always fail for a new user.