### PR TITLE
update nixpkgs to 785162a20e3f4c213774eeaf561a8befadf259d6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787360063,
-        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "lastModified": 1787245426,
+        "narHash": "sha256-nl63XHDlt1TeekDZzGt8VB4tJvUh5HFHmVAFAC7ZZ+E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "rev": "e18522ae92010fc80242c176e39e01c251c7cb86",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787178543,
-        "narHash": "sha256-c8U+1Eq7R/KfvtjR4i20epCIpHkZ5Unte0aNTppg568=",
+        "lastModified": 1787157586,
+        "narHash": "sha256-L9ZXrea7OG9iV1UPvVt7b+86gvsgnquJeT6lJja2xEA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1b746aff9ea1a224572e7d85fbb0b4cec5031833",
+        "rev": "8f35a058ffb760248d5e1ee52f75b541a50c80b1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787157586,
-        "narHash": "sha256-L9ZXrea7OG9iV1UPvVt7b+86gvsgnquJeT6lJja2xEA=",
+        "lastModified": 1787145617,
+        "narHash": "sha256-cUzNdWiSKbudb8PRjZBjCHk29C+aDdsgZAv17YXQYJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f35a058ffb760248d5e1ee52f75b541a50c80b1",
+        "rev": "785162a20e3f4c213774eeaf561a8befadf259d6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787135253,
-        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787245426,
-        "narHash": "sha256-nl63XHDlt1TeekDZzGt8VB4tJvUh5HFHmVAFAC7ZZ+E=",
+        "lastModified": 1787178543,
+        "narHash": "sha256-c8U+1Eq7R/KfvtjR4i20epCIpHkZ5Unte0aNTppg568=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e18522ae92010fc80242c176e39e01c251c7cb86",
+        "rev": "1b746aff9ea1a224572e7d85fbb0b4cec5031833",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/ffb3c9b700e759be2ef13237c9d8f953b32a1e46...2c423e03bbafcff28bfadc6781a4a8257f205cb5 ❌
 - https://github.com/NixOS/nixpkgs/compare/ffb3c9b700e759be2ef13237c9d8f953b32a1e46...e18522ae92010fc80242c176e39e01c251c7cb86 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/ffb3c9b700e759be2ef13237c9d8f953b32a1e46...1b746aff9ea1a224572e7d85fbb0b4cec5031833 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/ffb3c9b700e759be2ef13237c9d8f953b32a1e46...8f35a058ffb760248d5e1ee52f75b541a50c80b1 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/ffb3c9b700e759be2ef13237c9d8f953b32a1e46...785162a20e3f4c213774eeaf561a8befadf259d6 (bisected in the past)