### PR TITLE
karakeep: remove obsolete Meilisearch setting

### DIFF
--- a/modules/services/karakeep.nix
+++ b/modules/services/karakeep.nix
@@ -256,7 +256,6 @@ in
         services.meilisearch = {
           masterKeyFile = cfg.meilisearchMasterKey.result.path;
           settings = {
-            experimental_dumpless_upgrade = true;
             env = "production";
           };
         };

--- a/test/services/karakeep.nix
+++ b/test/services/karakeep.nix
@@ -12,6 +12,7 @@ let
         "karakeep-browser.service"
         "karakeep-web.service"
         "karakeep-workers.service"
+        "meilisearch.service"
         "nginx.service"
       ];
     waitForPorts =


### PR DESCRIPTION
The failing Karakeep SSO job at https://github.com/ibizaman/selfhostblocks/actions/runs/32601131491/job/97099512653 shows Meilisearch 1.53 repeatedly rejecting experimental_dumpless_upgrade until the service reaches its start limit. Current nixpkgs enables the stable upgrade_db replacement by default, so stop emitting the removed setting and require Meilisearch to start in the Karakeep tests.