### PR TITLE
karakeep: use Node 22

### DIFF
--- a/modules/services/karakeep.nix
+++ b/modules/services/karakeep.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   shb,
   ...
 }:
@@ -197,6 +198,22 @@ in
         services.karakeep = {
           enable = true;
           meilisearch.enable = true;
+          # Node 24.19 can abort ObjectWrap addons during GC. Use the supported
+          # Node 22 LTS until a fixed Node 24 reaches nixpkgs.
+          # https://github.com/nodejs/node/issues/65446
+          # Manually landed on main: https://github.com/nodejs/node/commit/68321eff80918e324e9fdaf1aa8cee6db14b84f7
+          # Pending Node 24 backport: https://github.com/nodejs/node/pull/65042
+          # https://github.com/nodejs/Release#release-schedule
+          package = lib.mkDefault (
+            assert lib.assertMsg (pkgs.nodejs.version == "24.19.0") ''
+              The Karakeep Node 22 workaround expected nixpkgs to provide Node
+              24.19.0, but it now provides ${pkgs.nodejs.version}. Check whether
+              https://github.com/nodejs/node/pull/65042 has landed and retry
+              Karakeep with pkgs.karakeep. If fixed, remove the Node 22 override;
+              otherwise update this guard with evidence for retaining it.
+            '';
+            pkgs.karakeep.override { nodejs = pkgs.nodejs_22; }
+          );
 
           extraEnvironment = {
             PORT = toString cfg.port;


### PR DESCRIPTION
The Karakeep SSO VM aborted in better-sqlite3's Statement destructor under Node 24.19.0, as observed in https://github.com/ibizaman/selfhostblocks/actions/runs/32601131491/job/97099512653.

This matches Node's deterministic reproducer for a Node 24.19 ObjectWrap cleanup regression at https://github.com/nodejs/node/issues/65446. The fix is merged on Node main in https://github.com/nodejs/node/pull/63985, but its Node 24 backport at https://github.com/nodejs/node/pull/65042 remains open.

nixpkgs defaults to the affected Node 24.19. Node 26 does not enter LTS until October 2026, while Node 22 remains supported through April 2027 according to https://github.com/nodejs/Release#release-schedule. Use Node 22 as a temporary supported LTS workaround while preserving explicit package overrides.