### PR TITLE
update nixpkgs to 2ee0d3d5eb7c9566c5610c8a03d73ca38f753942

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787145617,
-        "narHash": "sha256-cUzNdWiSKbudb8PRjZBjCHk29C+aDdsgZAv17YXQYJg=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "785162a20e3f4c213774eeaf561a8befadf259d6",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1787317660,
+        "narHash": "sha256-rBNZ3DT+ZhvEIO4h6OAArvccVPY/PYuFkVlxrWujgqM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "2ee0d3d5eb7c9566c5610c8a03d73ca38f753942",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/785162a20e3f4c213774eeaf561a8befadf259d6...56c02bc00adcf003215cc4bd996d6efaf4cff188 ❌
 - https://github.com/NixOS/nixpkgs/compare/785162a20e3f4c213774eeaf561a8befadf259d6...2ee0d3d5eb7c9566c5610c8a03d73ca38f753942 (bisected in the past)