### PR TITLE
update nixpkgs to cc9352eae99e2aedad487ed786ce8eea3bc8e3bb

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1787408726,
+        "narHash": "sha256-tP6EEdmkoggLxbUVdrw00SjnhvdvHQ1hVFaLvIyZa/E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "b9cf832436bafdc70a6b9bb3ac57f2d3c1d6571c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787352177,
-        "narHash": "sha256-YyRk8dbFL392cvGXUqbFlqOhDDAs7QfNfozKQ105On8=",
+        "lastModified": 1787325969,
+        "narHash": "sha256-mQ2vdogpOqJWcwjkLBiyn/sbK5ABi76Ht0KwrWz6HUE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d4a7a940d1b0d699020988afd1194202fedf3e6",
+        "rev": "de505876dae44bbb3fc84dece60ba087b01b3b6f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787317660,
-        "narHash": "sha256-rBNZ3DT+ZhvEIO4h6OAArvccVPY/PYuFkVlxrWujgqM=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ee0d3d5eb7c9566c5610c8a03d73ca38f753942",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787325969,
-        "narHash": "sha256-mQ2vdogpOqJWcwjkLBiyn/sbK5ABi76Ht0KwrWz6HUE=",
+        "lastModified": 1787324240,
+        "narHash": "sha256-LGqiP2tJ8TDdV3fbWfyo2u8MexIZeQg6HXSHsmDRBsA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "de505876dae44bbb3fc84dece60ba087b01b3b6f",
+        "rev": "1f1b74bddaf14b5af4ce1c5af34bff1e553f6376",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787324240,
-        "narHash": "sha256-LGqiP2tJ8TDdV3fbWfyo2u8MexIZeQg6HXSHsmDRBsA=",
+        "lastModified": 1787320859,
+        "narHash": "sha256-XOUmDYlyntRHsKEy0AwNi/0rBhjY2qE3wrEUI1q/LZ4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f1b74bddaf14b5af4ce1c5af34bff1e553f6376",
+        "rev": "8560a017e8684f98831b162a77c6e51f9b75aefe",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787408726,
-        "narHash": "sha256-tP6EEdmkoggLxbUVdrw00SjnhvdvHQ1hVFaLvIyZa/E=",
+        "lastModified": 1787352177,
+        "narHash": "sha256-YyRk8dbFL392cvGXUqbFlqOhDDAs7QfNfozKQ105On8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b9cf832436bafdc70a6b9bb3ac57f2d3c1d6571c",
+        "rev": "5d4a7a940d1b0d699020988afd1194202fedf3e6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787320859,
-        "narHash": "sha256-XOUmDYlyntRHsKEy0AwNi/0rBhjY2qE3wrEUI1q/LZ4=",
+        "lastModified": 1787320455,
+        "narHash": "sha256-BmRixiGZizBRws+FZ0Ojn447Z9RlxdczfjnfLLvCsDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8560a017e8684f98831b162a77c6e51f9b75aefe",
+        "rev": "cc9352eae99e2aedad487ed786ce8eea3bc8e3bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942...56c02bc00adcf003215cc4bd996d6efaf4cff188 ❌
 - https://github.com/NixOS/nixpkgs/compare/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942...b9cf832436bafdc70a6b9bb3ac57f2d3c1d6571c (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942...5d4a7a940d1b0d699020988afd1194202fedf3e6 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942...de505876dae44bbb3fc84dece60ba087b01b3b6f (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942...1f1b74bddaf14b5af4ce1c5af34bff1e553f6376 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942...8560a017e8684f98831b162a77c6e51f9b75aefe (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/2ee0d3d5eb7c9566c5610c8a03d73ca38f753942...cc9352eae99e2aedad487ed786ce8eea3bc8e3bb (bisected in the past)