### PR TITLE
update nixpkgs to c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787580426,
-        "narHash": "sha256-u2Smf3sqVaJB4JRMGpgglJ8QwSl1ijzYukHb4pwwRQ0=",
+        "lastModified": 1787433211,
+        "narHash": "sha256-7SCNySfoltK8IFRU1uGroyJicYzGRPjZSHF0xKEFqXU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a96a4723c8e3e170b6a504a01d789d2bc3eeedf",
+        "rev": "14eb18c3176fd8435cb15114bcadf951cd75ccba",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787335761,
-        "narHash": "sha256-Q/P693fNw8qnK51yikNtbrZRklwSULc3HtxoI1OQNag=",
+        "lastModified": 1787326066,
+        "narHash": "sha256-yOa5CZo1tWsf7G6V/LcrYO6iT75K1LSImhOYclA/wIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89b717b30424bc8d955a54e0a72bbb6cfcdd8267",
+        "rev": "204c0af5fb22366ec410bde3d9d8d9b121261ac5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787366474,
-        "narHash": "sha256-43EfzVQJqDE+GiE3SbBehWhWETF5RW+kmzit5gJh3mQ=",
+        "lastModified": 1787342264,
+        "narHash": "sha256-WARvgoVnWvwKHjK8qaNWJDRRMH+7b09N6dtdYtdHCMk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f963d1f253e9de5a3e704e8a8df15f055a3162b7",
+        "rev": "a3d1ef270062fe6bc82b98ab49ce5cc32fab4154",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787433211,
-        "narHash": "sha256-7SCNySfoltK8IFRU1uGroyJicYzGRPjZSHF0xKEFqXU=",
+        "lastModified": 1787366474,
+        "narHash": "sha256-43EfzVQJqDE+GiE3SbBehWhWETF5RW+kmzit5gJh3mQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14eb18c3176fd8435cb15114bcadf951cd75ccba",
+        "rev": "f963d1f253e9de5a3e704e8a8df15f055a3162b7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787320455,
-        "narHash": "sha256-BmRixiGZizBRws+FZ0Ojn447Z9RlxdczfjnfLLvCsDc=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cc9352eae99e2aedad487ed786ce8eea3bc8e3bb",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787900134,
-        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
+        "lastModified": 1787580426,
+        "narHash": "sha256-u2Smf3sqVaJB4JRMGpgglJ8QwSl1ijzYukHb4pwwRQ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
+        "rev": "6a96a4723c8e3e170b6a504a01d789d2bc3eeedf",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787326066,
-        "narHash": "sha256-yOa5CZo1tWsf7G6V/LcrYO6iT75K1LSImhOYclA/wIE=",
+        "lastModified": 1787323738,
+        "narHash": "sha256-7PcZV6h+rw/GvDcfTFGNqT/My6q7GeA6M59setK+2kM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "204c0af5fb22366ec410bde3d9d8d9b121261ac5",
+        "rev": "c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787342264,
-        "narHash": "sha256-WARvgoVnWvwKHjK8qaNWJDRRMH+7b09N6dtdYtdHCMk=",
+        "lastModified": 1787335761,
+        "narHash": "sha256-Q/P693fNw8qnK51yikNtbrZRklwSULc3HtxoI1OQNag=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3d1ef270062fe6bc82b98ab49ce5cc32fab4154",
+        "rev": "89b717b30424bc8d955a54e0a72bbb6cfcdd8267",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c ❌
 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...6a96a4723c8e3e170b6a504a01d789d2bc3eeedf (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...14eb18c3176fd8435cb15114bcadf951cd75ccba (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...f963d1f253e9de5a3e704e8a8df15f055a3162b7 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...a3d1ef270062fe6bc82b98ab49ce5cc32fab4154 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...89b717b30424bc8d955a54e0a72bbb6cfcdd8267 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...204c0af5fb22366ec410bde3d9d8d9b121261ac5 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/cc9352eae99e2aedad487ed786ce8eea3bc8e3bb...c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc (bisected in the past)