### PR TITLE
update nixpkgs to deffda9d63b04c01b286ef7b3bdc32010ac793c7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787323738,
-        "narHash": "sha256-7PcZV6h+rw/GvDcfTFGNqT/My6q7GeA6M59setK+2kM=",
+        "lastModified": 1788179007,
+        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc",
+        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787735473,
-        "narHash": "sha256-3sjoTunw3YkXM/NXID24Dwy32fOc9xDU3KFBzg+JWQk=",
+        "lastModified": 1787498959,
+        "narHash": "sha256-lzhV7ZEffQkw4t0LW16nzQX/itXUMEGQuhI3SPqAwSM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b09eb55eabeba94c9e2d45285073f0e77aea1b42",
+        "rev": "35b0754ae7c9095d0e16220a2d82597bbfd69b3d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788179007,
-        "narHash": "sha256-hn1oU2rue2SYK8dAr8+WNZWtbsz1S2W5mnHlSEuh3bo=",
+        "lastModified": 1787735473,
+        "narHash": "sha256-3sjoTunw3YkXM/NXID24Dwy32fOc9xDU3KFBzg+JWQk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34ab99075ac4f7e40cf037eef32cb1c360bb85e9",
+        "rev": "b09eb55eabeba94c9e2d45285073f0e77aea1b42",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787409350,
-        "narHash": "sha256-/K8m268xLg3bdBDM3LKmG4o4LIKYUc3LyHArzVbZqj4=",
+        "lastModified": 1787352374,
+        "narHash": "sha256-rvXQoSNLoPhRE8J+b0qqNrv4ZPzxaUf4q3BMx2vy6so=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a9d7c5a803c3d29f411851593b7e7b58d644da7d",
+        "rev": "3321474cd9079c0f47509982a9d033fd244d9796",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787352374,
-        "narHash": "sha256-rvXQoSNLoPhRE8J+b0qqNrv4ZPzxaUf4q3BMx2vy6so=",
+        "lastModified": 1787340838,
+        "narHash": "sha256-rovlcjXku5GKN4DL2oDKg4autLNe4hc1FZixyEVyrmk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3321474cd9079c0f47509982a9d033fd244d9796",
+        "rev": "7d028ca4fbbd38f27c27ced327f3589ef26baea3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787498959,
-        "narHash": "sha256-lzhV7ZEffQkw4t0LW16nzQX/itXUMEGQuhI3SPqAwSM=",
+        "lastModified": 1787409350,
+        "narHash": "sha256-/K8m268xLg3bdBDM3LKmG4o4LIKYUc3LyHArzVbZqj4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35b0754ae7c9095d0e16220a2d82597bbfd69b3d",
+        "rev": "a9d7c5a803c3d29f411851593b7e7b58d644da7d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787326922,
-        "narHash": "sha256-9PCEEHz8Y16rliH1hpKWHaVEtCfYp8JljggsNGi9kI8=",
+        "lastModified": 1787325834,
+        "narHash": "sha256-ccqC4zr9XjqP9dY65vX6AC/TNUYrrgHfvKz49qjkG1I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7a678191317d9010e8f417423eeb746fe49f1b2",
+        "rev": "deffda9d63b04c01b286ef7b3bdc32010ac793c7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787340838,
-        "narHash": "sha256-rovlcjXku5GKN4DL2oDKg4autLNe4hc1FZixyEVyrmk=",
+        "lastModified": 1787335761,
+        "narHash": "sha256-Q/P693fNw8qnK51yikNtbrZRklwSULc3HtxoI1OQNag=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7d028ca4fbbd38f27c27ced327f3589ef26baea3",
+        "rev": "89b717b30424bc8d955a54e0a72bbb6cfcdd8267",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787335761,
-        "narHash": "sha256-Q/P693fNw8qnK51yikNtbrZRklwSULc3HtxoI1OQNag=",
+        "lastModified": 1787326922,
+        "narHash": "sha256-9PCEEHz8Y16rliH1hpKWHaVEtCfYp8JljggsNGi9kI8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89b717b30424bc8d955a54e0a72bbb6cfcdd8267",
+        "rev": "a7a678191317d9010e8f417423eeb746fe49f1b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...34ab99075ac4f7e40cf037eef32cb1c360bb85e9 ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...b09eb55eabeba94c9e2d45285073f0e77aea1b42 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...35b0754ae7c9095d0e16220a2d82597bbfd69b3d (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...a9d7c5a803c3d29f411851593b7e7b58d644da7d (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...3321474cd9079c0f47509982a9d033fd244d9796 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...7d028ca4fbbd38f27c27ced327f3589ef26baea3 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...89b717b30424bc8d955a54e0a72bbb6cfcdd8267 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...a7a678191317d9010e8f417423eeb746fe49f1b2 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/c32ae8ea6e5db97a16c3e9ef9f6d5dbdc5f348cc...deffda9d63b04c01b286ef7b3bdc32010ac793c7 (bisected in the past)