### PR TITLE
update nixpkgs to d6524aaca2ff07876657ae2b323f24be4874944b

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788812507,
-        "narHash": "sha256-fuwLmFMMSkoNrk7urqU6+Dzac66uahlplexLDwPF4OM=",
+        "lastModified": 1788881743,
+        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb80c0ff02216a779d59534c975caf0e1d327bdc",
+        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/cb80c0ff02216a779d59534c975caf0e1d327bdc...d6524aaca2ff07876657ae2b323f24be4874944b