### PR TITLE
update nixpkgs to 588ef4b91830f6042529481d4a6d1c7173496506

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788935898,
-        "narHash": "sha256-BBNCOLVRJSqgjvr6Et8D65T1l3VGRdS0eBWPe51NPOw=",
+        "lastModified": 1788904439,
+        "narHash": "sha256-qpjPXkXWvkAslFI8e5a2I3kG5K3HHpT81Ehivze3t44=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2986ab2c1aa739596247bafd6ad4a80a785f20e8",
+        "rev": "588ef4b91830f6042529481d4a6d1c7173496506",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1789006805,
-        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
+        "lastModified": 1788935898,
+        "narHash": "sha256-BBNCOLVRJSqgjvr6Et8D65T1l3VGRdS0eBWPe51NPOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
+        "rev": "2986ab2c1aa739596247bafd6ad4a80a785f20e8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788881743,
-        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/d6524aaca2ff07876657ae2b323f24be4874944b...8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe ❌
 - https://github.com/NixOS/nixpkgs/compare/d6524aaca2ff07876657ae2b323f24be4874944b...2986ab2c1aa739596247bafd6ad4a80a785f20e8 (bisected in the past) ❌
 - https://github.com/NixOS/nixpkgs/compare/d6524aaca2ff07876657ae2b323f24be4874944b...588ef4b91830f6042529481d4a6d1c7173496506 (bisected in the past)