### PR TITLE
update nixpkgs to 6737a8f6624cd76df74dee92b55238e51098c94d

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1789006805,
-        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
+        "lastModified": 1788954073,
+        "narHash": "sha256-mWq9euerJfYAsR0wMLEreIbMbADKfEii+jstRh1C0xA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
+        "rev": "6737a8f6624cd76df74dee92b55238e51098c94d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788904439,
-        "narHash": "sha256-qpjPXkXWvkAslFI8e5a2I3kG5K3HHpT81Ehivze3t44=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "588ef4b91830f6042529481d4a6d1c7173496506",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated nixpkgs update. Latest tries:

 - https://github.com/NixOS/nixpkgs/compare/588ef4b91830f6042529481d4a6d1c7173496506...8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe ❌
 - https://github.com/NixOS/nixpkgs/compare/588ef4b91830f6042529481d4a6d1c7173496506...6737a8f6624cd76df74dee92b55238e51098c94d (bisected in the past)